### PR TITLE
Makes it possible to set docker_bin in crunch-job

### DIFF
--- a/services/api/script/crunch-dispatch.rb
+++ b/services/api/script/crunch-dispatch.rb
@@ -63,6 +63,8 @@ class Dispatcher
       raise "No CRUNCH_JOB_BIN env var, and crunch-job not in path."
     end
 
+    @docker_bin = (ENV['CRUNCH_JOB_DOCKER_BIN'] || "/usr/bin/docker.io")
+
     @arvados_internal = Rails.configuration.git_internal_dir
     if not File.exists? @arvados_internal
       $stderr.puts `mkdir -p #{@arvados_internal.shellescape} && git init --bare #{@arvados_internal.shellescape}`
@@ -419,7 +421,8 @@ class Dispatcher
       cmd_args += [@crunch_job_bin,
                    '--job-api-token', @authorizations[job.uuid].api_token,
                    '--job', job.uuid,
-                   '--git-dir', @arvados_internal]
+                   '--git-dir', @arvados_internal,
+                   '--docker-bin', @docker_bin]
 
       if @todo_job_retries.include?(job.uuid)
         cmd_args << "--force-unlock"


### PR DESCRIPTION
Adds a new environment variable (CRUNCH_JOB_DOCKER_BIN) that
crunch-dispatch.rb passes along to crunch-job (or if unset, it
defaults to "/usr/bin/docker.io" which is already the default for
crunch-job).

This is useful because it allows one to start the crunch dispatcher using a 
docker other than `/usr/bin/docker.io`, which is a relatively common 
situation (e.g. on many distros docker is packaged as `/usr/bin/docker`). 