### PR TITLE
Adds error handling for command not found

### DIFF
--- a/sdk/cli/bin/arv
+++ b/sdk/cli/bin/arv
@@ -87,6 +87,14 @@ end
 
 subcommands = %w(copy create edit keep pipeline run tag ws)
 
+def exec_bin bin, opts
+  @bin_path = `which #{bin}`.strip
+  if @bin_path.empty?
+    raise "#{bin}: command not found"
+  end
+  exec @bin_path, *opts
+end
+
 def check_subcommands client, arvados, subcommand, global_opts, remaining_opts
   case subcommand
   when 'create'
@@ -94,17 +102,17 @@ def check_subcommands client, arvados, subcommand, global_opts, remaining_opts
   when 'edit'
     arv_edit client, arvados, global_opts, remaining_opts
   when 'copy', 'tag', 'ws', 'run'
-    exec `which arv-#{subcommand}`.strip, *remaining_opts
+    exec_bin "arv-#{subcommand}", remaining_opts
   when 'keep'
     @sub = remaining_opts.shift
     if ['get', 'put', 'ls', 'normalize'].index @sub then
       # Native Arvados
-      exec `which arv-#{@sub}`.strip, *remaining_opts
+      exec_bin "arv-#{@sub}", remaining_opts
     elsif ['less', 'check'].index @sub then
       # wh* shims
-      exec `which wh#{@sub}`.strip, *remaining_opts
+      exec_bin "wh#{@sub}", remaining_opts
     elsif @sub == 'docker'
-      exec `which arv-keepdocker`.strip, *remaining_opts
+      exec_bin "arv-keepdocker", remaining_opts
     else
       puts "Usage: arv keep [method] [--parameters]\n"
       puts "Use 'arv keep [method] --help' to get more information about specific methods.\n\n"
@@ -114,7 +122,7 @@ def check_subcommands client, arvados, subcommand, global_opts, remaining_opts
   when 'pipeline'
     sub = remaining_opts.shift
     if sub == 'run'
-      exec `which arv-run-pipeline-instance`.strip, *remaining_opts
+      exec_bin "arv-run-pipeline-instance", remaining_opts
     else
       puts "Usage: arv pipeline [method] [--parameters]\n"
       puts "Use 'arv pipeline [method] --help' to get more information about specific methods.\n\n"


### PR DESCRIPTION
Raises a "command not found" error if arv-* commands are not
found. 