### PR TITLE
Fixes 7205 (https://arvados.org/issues/7205)

### DIFF
--- a/sdk/cli/bin/arv
+++ b/sdk/cli/bin/arv
@@ -258,11 +258,6 @@ def arv_edit client, arvados, global_opts, remaining_opts
     exit 255
   end
 
-  if not $stdout.tty?
-    puts "Not connected to a TTY, cannot run interactive editor."
-    exit 1
-  end
-
   # determine controller
 
   m = /([a-z0-9]{5})-([a-z0-9]{5})-([a-z0-9]{15})/.match uuid

--- a/sdk/cli/bin/arv
+++ b/sdk/cli/bin/arv
@@ -309,9 +309,9 @@ def arv_edit client, arvados, global_opts, remaining_opts
                        authorization: 'OAuth2 '+ENV['ARVADOS_API_TOKEN']
                      })
       results = check_response result
-      puts "Updated object #{results['uuid']}"
+      STDERR.puts "Updated object #{results['uuid']}"
     else
-      puts "Object is unchanged, did not update."
+      STDERR.puts "Object is unchanged, did not update."
     end
   end
 


### PR DESCRIPTION
Removes unnecessary check that stdout is a TTY and moves printing of `arv edit` messages out-of-band

Messages regarding update of object after edit are now printed out-of-band to STDERR rather than to STDOUT where they might mix with the output of non-interactive "editors".
