### PR TITLE
Change ssh public key to 600 after key-sync

### DIFF
--- a/services/login-sync/bin/arvados-login-sync
+++ b/services/login-sync/bin/arvados-login-sync
@@ -100,6 +100,7 @@ begin
     FileUtils.chown_R(l[:username], l[:username], userdotssh)
     File.chmod(0700, userdotssh)
     File.chmod(0750, @homedir)
+    File.chmod(0600, userauthkeys)
   end
 
   devnull.close


### PR DESCRIPTION
OpenSSH will refuse to use an authorized_key file if it is group-writable or global-writable.
In RH-based distributes, umask is default to 002, which means the file will be 664, which violate the rule, and stop the ssh-key login procedure.
For the other distributions which probably don't have this problem, this is for safety sake.

(related with https://dev.arvados.org/issues/7388)