### PR TITLE
Adds preliminar support for Arvados docker running on OSX

### DIFF
--- a/docker/arvdock
+++ b/docker/arvdock
@@ -51,7 +51,12 @@ function bridge_ip_address {
     local bridge_name=$1
     # FIXME: add a more robust check here.
     # because ip command could be mising, multiple docker bridges could be there.. etc.
-    echo $(ip --oneline --family inet addr show dev "$bridge_name" | awk '{ print $4 }'| cut -d/ -f1 )
+    iptool=`which ip`
+    if [[ "$iptool" != '' ]]; then
+      echo $(ip --oneline --family inet addr show dev "$bridge_name" | awk '{ print $4 }'| cut -d/ -f1 )
+    else
+      echo $(ipconfig getifaddr en0)
+    fi
 }
 
 function start_container {

--- a/docker/arvdock
+++ b/docker/arvdock
@@ -51,12 +51,14 @@ function bridge_ip_address {
     local bridge_name=$1
     # FIXME: add a more robust check here.
     # because ip command could be mising, multiple docker bridges could be there.. etc.
-    iptool=`which ip`
+	iptool=`which ip`
     if [[ "$iptool" != '' ]]; then
-      echo $(ip --oneline --family inet addr show dev "$bridge_name" | awk '{ print $4 }'| cut -d/ -f1 )
-    else
-      echo $(ipconfig getifaddr en0)
-    fi
+    	echo $(ip --oneline --family inet addr show dev "$bridge_name" | awk '{ print $4 }'| cut -d/ -f1 )
+	else
+		echo $(docker-machine ssh dev "ip --oneline --family inet addr show dev docker0 | sed -r 's/.*inet ([^ ]+)\/.*/\1/'")
+#		echo $(ipconfig getifaddr en0)
+	fi
+
 }
 
 function start_container {


### PR DESCRIPTION
The check still needs to be made more robust (FIXME), but at least it does instantiate/run the docker containers in a boot2docker and virtualbox backed docker setup on OSX Yosemite.

/ping @guillermo-carrasco, might interest you too.
