### PR TITLE
remove non-existing folder in user scripts' path

### DIFF
--- a/sdk/cli/bin/crunch-job
+++ b/sdk/cli/bin/crunch-job
@@ -918,12 +918,12 @@ for (my $todo_ptr = 0; $todo_ptr <= $#jobstep_todo; $todo_ptr ++)
       $command .= "--env=\QHOME=$ENV{HOME}\E ";
       $command .= "\Q$docker_hash\E ";
       $command .= "stdbuf --output=0 --error=0 ";
-      $command .= "perl - $ENV{CRUNCH_SRC}/crunch_scripts/" . $Job->{"script"};
+      $command .= "perl - $ENV{CRUNCH_SRC}/" . $Job->{"script"};
     } else {
       # Non-docker run
       $command .= "crunchstat -cgroup-root=/sys/fs/cgroup -poll=10000 ";
       $command .= "stdbuf --output=0 --error=0 ";
-      $command .= "perl - $ENV{CRUNCH_SRC}/crunch_scripts/" . $Job->{"script"};
+      $command .= "perl - $ENV{CRUNCH_SRC}/" . $Job->{"script"};
     }
 
     my @execargs = ('bash', '-c', $command);


### PR DESCRIPTION
When running a pipeline, it said:
```
[Crunch] Using Arvados SDK:
stderr [Crunch] arvados-python-client==0.1.20151020215415
stderr Cannot exec `/tmp/crunch-job/src/crunch_scripts/hash.py`: No such file or directory at - line 108.
```

I logged in on the compute node, and see scripts directly under /tmp/crunch-job/src:
```
[root@compute0 src]# ls /tmp/crunch-job/src
hash.py
```

The crunch_scripts folder is not mentioned elsewhere. This pull request removed this non-existing folder, and make everyone happy.