### PR TITLE
adds fpm-info.sh to python-arvados-fuse to ignore the iteration number (for deb packages)

### DIFF
--- a/services/fuse/fpm-info.sh
+++ b/services/fuse/fpm-info.sh
@@ -1,0 +1,6 @@
+case "$TARGET" in
+    debian* | ubuntu*)
+        # FIXME: Remove once support for llfuse 0.42+ is in place
+        fpm_args+=(--deb-ignore-iteration-in-dependencies)
+        ;;
+esac


### PR DESCRIPTION
The '==' version pinning introduced in 9eb25cddc8bf1d9768d0bb9dae71ac91754e3480 is breaking installation of deb packages for python-arvados-fuse (as the python-llfuse backport is using "--iteration 2" and thus in dpkg namespace, the version is "0.41.1-2". 

I've fixed this by telling fpm not to enforce versions at the iteration level (by passing `--deb-ignore-iteration-in-dependencies`). 

An alternative fix could be to set the version to `llfuse<=0.41.1` instead of `llfuse==0.41.1`