### PR TITLE
8484: adds sanity check on number of collections retrieved

### DIFF
--- a/services/datamanager/collection/collection.go
+++ b/services/datamanager/collection/collection.go
@@ -227,6 +227,17 @@ func GetCollections(params GetCollectionsParams) (results ReadCollections, err e
 		}
 	}
 
+	if totalCollections < initialNumberOfCollectionsAvailable {
+		err = fmt.Errorf("Initially there were %d collections available, "+
+				"but we only retrieved %d. Refusing to continue as "+
+				"this could indicate an otherwise undetected "+
+				"failure, though it is also possible that "+
+				"collections were deleted by another process "+
+				"while datamanager was running.",
+				initialNumberOfCollectionsAvailable, totalCollections)
+		return
+	}
+
 	// Write the heap profile for examining memory usage
 	err = WriteHeapProfile()
 

--- a/services/datamanager/collection/collection.go
+++ b/services/datamanager/collection/collection.go
@@ -228,6 +228,7 @@ func GetCollections(params GetCollectionsParams) (results ReadCollections, err e
 	}
 
 	// Make one final API request to verify that we have processed all collections available up to the latest modification date
+	var collections SdkCollectionList
 	sdkParams["filters"].([][]string)[0][1] = "<="
 	sdkParams["limit"] = 0
 	err = params.Client.List("collections", sdkParams, &collections)


### PR DESCRIPTION
Changes GetCollections() to return an error if the number
of collections retrieved is less than the initial number
of collections.