### PR TITLE
8508: explicitly create "bad paths"

### DIFF
--- a/services/datamanager/datamanager_test.go
+++ b/services/datamanager/datamanager_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"path"
 )
 
 var arv arvadosclient.ArvadosClient
@@ -537,12 +538,35 @@ func TestPutAndGetBlocks_NoErrorDuringSingleRun(t *testing.T) {
 	testOldBlocksNotDeletedOnDataManagerError(t, "", "", false, false)
 }
 
+func createBadPath(t *testing.T) (badpath string) {
+	tempdir, err := ioutil.TempDir("", "bad")
+	if err != nil {
+		t.Fatalf("Could not create temporary directory for bad path: %v", err)
+	}
+	badpath = path.Join(tempdir, "bad")
+	return
+}
+
+func destroyBadPath(t *testing.T, badpath string) () {
+	tempdir := path.Join(badpath, "..")
+	err := os.Remove(tempdir)
+	if err != nil {
+		t.Fatalf("Could not remove bad path temporary directory %v: %v", tempdir, err)
+		return
+	}
+	return
+}
+
 func TestPutAndGetBlocks_ErrorDuringGetCollectionsBadWriteTo(t *testing.T) {
-	testOldBlocksNotDeletedOnDataManagerError(t, "/badwritetofile", "", true, true)
+	badpath := createBadPath(t)
+	defer destroyBadPath(t, badpath)
+	testOldBlocksNotDeletedOnDataManagerError(t, path.Join(badpath, "writetofile"), "", true, true)
 }
 
 func TestPutAndGetBlocks_ErrorDuringGetCollectionsBadHeapProfileFilename(t *testing.T) {
-	testOldBlocksNotDeletedOnDataManagerError(t, "", "/badheapprofilefile", true, true)
+	badpath := createBadPath(t)
+	defer destroyBadPath(t, badpath)
+	testOldBlocksNotDeletedOnDataManagerError(t, "", path.Join(badpath, "heapprofilefile"), true, true)
 }
 
 // Create some blocks and backdate some of them.


### PR DESCRIPTION
Rather than assuming we can't write to '/', this change
creates a temporary directory and then refers to a nonexistent
path within it.