### PR TITLE
Fix path to docker metadata file

### DIFF
--- a/sdk/python/arvados/commands/keepdocker.py
+++ b/sdk/python/arvados/commands/keepdocker.py
@@ -399,7 +399,8 @@ def main(arguments=None, stdout=sys.stdout):
     # Read the image metadata and make Arvados links from it.
     image_file.seek(0)
     image_tar = tarfile.open(fileobj=image_file)
-    json_file = image_tar.extractfile(image_tar.getmember(image_hash + '/json'))
+    # image_hash has format: sha25-<hash>. Remove first seven characters to get hash
+    json_file = image_tar.extractfile(image_tar.getmember(image_hash[7:] + '.json'))
     image_metadata = json.load(json_file)
     json_file.close()
     image_tar.close()


### PR DESCRIPTION
Docker images do not have a `json` file at their root, but rather, a set of
layers, which use a `json` file to manage metadata for the layer. At the root,
the image has a file for metadata named `<hash>.json`. This change instructs
keep to look at that file for the metadata rather than the `json` file.

An issue for this bug has been created here: https://dev.arvados.org/issues/9628
