### PR TITLE
Support Docker v1.10+ hashes that include sha256: prefix in `crunch-job`.

### DIFF
--- a/sdk/cli/bin/crunch-job
+++ b/sdk/cli/bin/crunch-job
@@ -2066,7 +2066,7 @@ sub find_docker_image {
       }
     }
   }
-  if (defined($filename) and ($filename =~ /^([0-9A-Fa-f]{64})\.tar$/)) {
+  if (defined($filename) and ($filename =~ /^((?:sha256:)?[0-9A-Fa-f]{64})\.tar$/)) {
     return ($streamname, $1);
   } else {
     return (undef, undef);


### PR DESCRIPTION
I had to make this tweak to get jobs running using Docker 1.12.  This is very similar to [this change](https://github.com/curoverse/arvados/commit/ce5e483d141207a9adddfb82bc8073caaf555907#diff-5f47db9c5557a442f161cbbecd458794R317), but in `crunch-job`.