### PR TITLE
9998 unsigned manifest

### DIFF
--- a/services/api/app/controllers/arvados/v1/collections_controller.rb
+++ b/services/api/app/controllers/arvados/v1/collections_controller.rb
@@ -183,8 +183,8 @@ class Arvados::V1::CollectionsController < ApplicationController
 
   def load_limit_offset_order_params *args
     if action_name == 'index'
-      # Omit manifest_text from index results unless expressly selected.
-      @select ||= model_class.selectable_attributes - ["manifest_text"]
+      # Omit manifest_text and unsigned_manifest_text from index results unless expressly selected.
+      @select ||= model_class.selectable_attributes - ["manifest_text","unsigned_manifest_text"]
     end
     super
   end

--- a/services/api/app/controllers/arvados/v1/collections_controller.rb
+++ b/services/api/app/controllers/arvados/v1/collections_controller.rb
@@ -31,6 +31,8 @@ class Arvados::V1::CollectionsController < ApplicationController
 
   def show
     if @object.is_a? Collection
+      # Omit unsigned_manifest_text
+      @select ||= model_class.selectable_attributes - ["unsigned_manifest_text"]
       super
     else
       send_json @object

--- a/services/api/app/models/collection.rb
+++ b/services/api/app/models/collection.rb
@@ -26,6 +26,7 @@ class Collection < ArvadosModel
     t.add :properties
     t.add :portable_data_hash
     t.add :signed_manifest_text, as: :manifest_text
+    t.add :unsigned_manifest_text, as: :unsigned_manifest_text
     t.add :replication_desired
     t.add :replication_confirmed
     t.add :replication_confirmed_at
@@ -43,6 +44,7 @@ class Collection < ArvadosModel
                 # We need expires_at to determine the correct
                 # timestamp in signed_manifest_text.
                 'manifest_text' => ['manifest_text', 'expires_at'],
+                'unsigned_manifest_text' => ['manifest_text'],
                 )
   end
 
@@ -214,6 +216,12 @@ class Collection < ArvadosModel
     rescue ArgumentError => e
       errors.add :manifest_text, e.message
       false
+    end
+  end
+
+  def unsigned_manifest_text
+    if has_attribute? :manifest_text
+      @unsigned_manifest_text = manifest_text
     end
   end
 

--- a/services/keep-balance/collection.go
+++ b/services/keep-balance/collection.go
@@ -43,7 +43,7 @@ func EachCollection(c *arvados.Client, pageSize int, f func(arvados.Collection) 
 	params := arvados.ResourceListParams{
 		Limit:  &limit,
 		Order:  "modified_at, uuid",
-		Select: []string{"uuid", "manifest_text", "modified_at", "portable_data_hash", "replication_desired"},
+		Select: []string{"uuid", "unsigned_manifest_text", "modified_at", "portable_data_hash", "replication_desired"},
 	}
 	var last arvados.Collection
 	var filterTime time.Time


### PR DESCRIPTION
Adds a new pseudo-column called `unsigned_manifest_text` to collection objects returned by the API server. The intent is to save time when listing manifests whenever signed locators are not required.

This `unsigned_manifest_text` column is never included when a collection is `show`n (i.e. on get/update/create) and it won't be returned in index output unless an explicit select list is provided and it is explicitly listed. 

Also changes keep-balance to request `unsigned_manifest_text` instead of `manifest_text` and updates Go SDK to use `UnsignedManifestText` in `SizedDigests()` if `ManifestText` is not available. 