### PR TITLE
Fixes API server to return default columns for collections

### DIFF
--- a/services/api/app/controllers/arvados/v1/collections_controller.rb
+++ b/services/api/app/controllers/arvados/v1/collections_controller.rb
@@ -182,10 +182,10 @@ class Arvados::V1::CollectionsController < ApplicationController
   protected
 
   def load_limit_offset_order_params *args
+    super
     if action_name == 'index'
       # Omit manifest_text from index results unless expressly selected.
       @select ||= model_class.selectable_attributes - ["manifest_text"]
     end
-    super
   end
 end


### PR DESCRIPTION
Prior to this fix, if a request has a query param `select=`
(as opposed to just omitting `select` entirely), the API
server would return a full set of columns rather than
enforcing its own defaults.

Fixes #10517, assuming this was a bug and not a feature.