### PR TITLE
9998 add count option to list method

### DIFF
--- a/doc/sdk/cli/reference.html.textile.liquid
+++ b/doc/sdk/cli/reference.html.textile.liquid
@@ -60,7 +60,7 @@ Arguments accepted by the @list@ subcommand include:
     --order, -r <s>:     Order in which to return matching users.
    --select, -s <s>:     Select which fields to return
      --distinct, -d:     Return each distinct object.
-     --no-count, -n:     Don't count items_available.
+         --no-count:     Don't count items_available.
 </pre>
 
 The @--filters@ option takes a string describing a JSON list of filters on which the returned resources should be returned. Each filter is a three-element list of _[field, operator, value]_, where the _operator_ may be one of @=@, @<@, @<=@, @>@, @>=@, @!=@, @like@, or @ilike@.

--- a/doc/sdk/cli/reference.html.textile.liquid
+++ b/doc/sdk/cli/reference.html.textile.liquid
@@ -59,7 +59,8 @@ Arguments accepted by the @list@ subcommand include:
   --filters, -f <s>:     Conditions for filtering users.
     --order, -r <s>:     Order in which to return matching users.
    --select, -s <s>:     Select which fields to return
-     --distinct, -d:     Return each distinct object
+     --distinct, -d:     Return each distinct object.
+     --no-count, -n:     Don't count items_available.
 </pre>
 
 The @--filters@ option takes a string describing a JSON list of filters on which the returned resources should be returned. Each filter is a three-element list of _[field, operator, value]_, where the _operator_ may be one of @=@, @<@, @<=@, @>@, @>=@, @!=@, @like@, or @ilike@.

--- a/sdk/go/arvados/resource_list.go
+++ b/sdk/go/arvados/resource_list.go
@@ -5,11 +5,13 @@ import "encoding/json"
 // ResourceListParams expresses which results are requested in a
 // list/index API.
 type ResourceListParams struct {
-	Select  []string `json:"select,omitempty"`
-	Filters []Filter `json:"filters,omitempty"`
-	Limit   *int     `json:"limit,omitempty"`
-	Offset  int      `json:"offset,omitempty"`
-	Order   string   `json:"order,omitempty"`
+	Select   []string `json:"select,omitempty"`
+	Filters  []Filter `json:"filters,omitempty"`
+	Limit    *int     `json:"limit,omitempty"`
+	Offset   int      `json:"offset,omitempty"`
+	Order    string   `json:"order,omitempty"`
+	Distinct bool     `json:"distinct,omitempty"`
+	Count    bool     `json:"count,omitempty"`
 }
 
 // A Filter restricts the set of records returned by a list/index API.

--- a/services/api/app/controllers/application_controller.rb
+++ b/services/api/app/controllers/application_controller.rb
@@ -482,7 +482,7 @@ class ApplicationController < ActionController::Base
       :limit => @limit,
       :items => @objects.as_api_response(nil, {select: @select})
     }
-    if params[:no_count].nil? || !params[:no_count]
+    if params[:count].nil? || params[:count]
       if @objects.respond_to? :except
         list[:items_available] = @objects.
           except(:limit).except(:offset).
@@ -550,7 +550,7 @@ class ApplicationController < ActionController::Base
       distinct: { type: 'boolean', required: false },
       limit: { type: 'integer', required: false, default: DEFAULT_LIMIT },
       offset: { type: 'integer', required: false, default: 0 },
-      no_count: { type: 'boolean', required: false, default: false },
+      count: { type: 'boolean', required: false, default: true},
     }
   end
 

--- a/services/api/app/controllers/application_controller.rb
+++ b/services/api/app/controllers/application_controller.rb
@@ -482,10 +482,12 @@ class ApplicationController < ActionController::Base
       :limit => @limit,
       :items => @objects.as_api_response(nil, {select: @select})
     }
-    if @objects.respond_to? :except
-      list[:items_available] = @objects.
-        except(:limit).except(:offset).
-        count(:id, distinct: true)
+    if params[:no_count].nil? || !params[:no_count]
+      if @objects.respond_to? :except
+        list[:items_available] = @objects.
+          except(:limit).except(:offset).
+          count(:id, distinct: true)
+      end
     end
     list
   end
@@ -548,6 +550,7 @@ class ApplicationController < ActionController::Base
       distinct: { type: 'boolean', required: false },
       limit: { type: 'integer', required: false, default: DEFAULT_LIMIT },
       offset: { type: 'integer', required: false, default: 0 },
+      no_count: { type: 'boolean', required: false, default: false },
     }
   end
 

--- a/services/api/app/controllers/arvados/v1/schema_controller.rb
+++ b/services/api/app/controllers/arvados/v1/schema_controller.rb
@@ -246,12 +246,17 @@ class Arvados::V1::SchemaController < ApplicationController
                 },
                 select: {
                   type: "array",
-                  description: "Select which fields to return",
+                  description: "Select which fields to return.",
                   location: "query"
                 },
                 distinct: {
                   type: "boolean",
-                  description: "Return each distinct object",
+                  description: "Return each distinct object.",
+                  location: "query"
+                },
+                no_count: {
+                  type: "boolean",
+                  description: "Don't count items_available.",
                   location: "query"
                 }
               },

--- a/services/api/app/controllers/arvados/v1/schema_controller.rb
+++ b/services/api/app/controllers/arvados/v1/schema_controller.rb
@@ -254,9 +254,10 @@ class Arvados::V1::SchemaController < ApplicationController
                   description: "Return each distinct object.",
                   location: "query"
                 },
-                no_count: {
+                count: {
                   type: "boolean",
-                  description: "Don't count items_available.",
+                  description: "Count items_available.",
+                  default: "true",
                   location: "query"
                 }
               },

--- a/services/keep-balance/collection.go
+++ b/services/keep-balance/collection.go
@@ -44,7 +44,7 @@ func EachCollection(c *arvados.Client, pageSize int, f func(arvados.Collection) 
 	params := arvados.ResourceListParams{
 		Limit:  &limit,
 		Order:  "modified_at, uuid",
-		Count: false,
+		Count:  false,
 		Select: []string{"uuid", "manifest_text", "modified_at", "portable_data_hash", "replication_desired"},
 	}
 	var last arvados.Collection

--- a/services/keep-balance/collection.go
+++ b/services/keep-balance/collection.go
@@ -11,6 +11,7 @@ func countCollections(c *arvados.Client, params arvados.ResourceListParams) (int
 	var page arvados.CollectionList
 	var zero int
 	params.Limit = &zero
+	params.Count = true
 	err := c.RequestAndDecode(&page, "GET", "arvados/v1/collections", nil, params)
 	return page.ItemsAvailable, err
 }
@@ -43,6 +44,7 @@ func EachCollection(c *arvados.Client, pageSize int, f func(arvados.Collection) 
 	params := arvados.ResourceListParams{
 		Limit:  &limit,
 		Order:  "modified_at, uuid",
+		Count: false,
 		Select: []string{"uuid", "manifest_text", "modified_at", "portable_data_hash", "replication_desired"},
 	}
 	var last arvados.Collection


### PR DESCRIPTION
When `count` (default: `true`) is false, the API server will not query 
the database for the count of items and it will not return `items_available` 
in the JSON output.

This is expected to offer a major performance improvement when
tables are large and the count is not needed, since postgres
can otherwise take far longer to answer the COUNT() query than
to answer the main query and return the requested list.

I had originally called this option `no_count` but that conflicted with 
the `arv` cli's automatic handling (in Trollop) of negated flag values. 
With the present implementation, all of the following would continue 
to include `items_available` in the output:
`arv collection list`
`arv collection list -c`
`arv collection list --count`

Whereas the negated count param would exclude it:
`arv collection list --no-count`

Also adds the `Count` (and missing `Distinct`) params to the Go SDK's ResourceListParams.

Finally, changes keep-balance to use `count=false` for all the collection retrievals except for at the beginning and end when a count is needed. 