### PR TITLE
11621 fix bwa-mem.cwl docker repo

### DIFF
--- a/doc/user/cwl/bwa-mem/bwa-mem.cwl
+++ b/doc/user/cwl/bwa-mem/bwa-mem.cwl
@@ -8,9 +8,9 @@ class: CommandLineTool
 
 hints:
   DockerRequirement:
-    dockerPull: biodckr/bwa
+    dockerPull: lh3lh3/bwa
 
-baseCommand: [bwa, mem]
+baseCommand: [mem]
 
 arguments:
   - {prefix: "-t", valueFrom: $(runtime.cores)}


### PR DESCRIPTION
Change from missing `biodckr/bwa` repo to minimal bwa docker image `lh3lh3/bwa` 
The new docker image has `bwa` set as entrypoint, so also change `baseCommand` from `[bwa, mem]` to `[mem]`
Fixes 11621