### PR TITLE
Allow hardcoding of protocol and port components of root_url

### DIFF
--- a/services/api/app/controllers/application_controller.rb
+++ b/services/api/app/controllers/application_controller.rb
@@ -81,11 +81,17 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
+    options = {}
     if Rails.configuration.host
-      {:host => Rails.configuration.host}
-    else
-      {}
+      options[:host] = Rails.configuration.host
     end
+    if Rails.configuration.port
+      options[:port] = Rails.configuration.port
+    end
+    if Rails.configuration.protocol
+      options[:protocol] = Rails.configuration.protocol
+    end
+    options
   end
 
   def index

--- a/services/api/config/application.default.yml
+++ b/services/api/config/application.default.yml
@@ -93,10 +93,12 @@ common:
   ### Overriding default advertised hostnames/URLs
   ###
 
-  # If not false, this is the hostname that will be used for root_url and
-  # advertised in the discovery document.  By default, use the default Rails
-  # logic for deciding on a hostname.
+  # If not false, this is the hostname, port, and protocol that will be used
+  # for root_url and advertised in the discovery document.  By default, use
+  # the default Rails logic for deciding on a hostname.
   host: false
+  port: false
+  protocol: false
 
   # Base part of SSH git clone url given with repository resources. If
   # true, the default "git@git.(uuid_prefix).arvadosapi.com:" is


### PR DESCRIPTION
Fixes 13809 with the option to hardcode all relevant components of root_url in the arvados `application.yml` configuration. 
