### PR TITLE
Allow Arvados model audit logging to be disabled

### DIFF
--- a/services/api/app/models/arvados_model.rb
+++ b/services/api/app/models/arvados_model.rb
@@ -764,8 +764,8 @@ class ArvadosModel < ActiveRecord::Base
   end
 
   def is_audit_logging_enabled?
-    return Rails.configuration.max_audit_log_age == 0 &&
-           Rails.configuration.max_audit_log_delete_batch > 0
+    return !(Rails.configuration.max_audit_log_age.to_i == 0 &&
+             Rails.configuration.max_audit_log_delete_batch.to_i > 0)
   end
 
   def log_start_state

--- a/services/api/app/models/arvados_model.rb
+++ b/services/api/app/models/arvados_model.rb
@@ -764,8 +764,8 @@ class ArvadosModel < ActiveRecord::Base
   end
 
   def is_audit_logging_enabled?
-    return Rails.configuration.max_audit_log_age == 0
-             and Rails.configuration.max_audit_log_delete_batch > 0
+    return Rails.configuration.max_audit_log_age == 0 &&
+           Rails.configuration.max_audit_log_delete_batch > 0
   end
 
   def log_start_state

--- a/services/api/app/models/arvados_model.rb
+++ b/services/api/app/models/arvados_model.rb
@@ -763,36 +763,51 @@ class ArvadosModel < ActiveRecord::Base
     end
   end
 
+  def is_audit_logging_enabled?
+    return Rails.configuration.max_audit_log_age == 0
+             and Rails.configuration.max_audit_log_delete_batch > 0
+  end
+
   def log_start_state
-    @old_attributes = Marshal.load(Marshal.dump(attributes))
-    @old_logged_attributes = Marshal.load(Marshal.dump(logged_attributes))
+    if is_audit_logging_enabled?
+      @old_attributes = Marshal.load(Marshal.dump(attributes))
+      @old_logged_attributes = Marshal.load(Marshal.dump(logged_attributes))
+    end
   end
 
   def log_change(event_type)
-    log = Log.new(event_type: event_type).fill_object(self)
-    yield log
-    log.save!
-    log_start_state
+    if is_audit_logging_enabled?
+      log = Log.new(event_type: event_type).fill_object(self)
+      yield log
+      log.save!
+      log_start_state
+    end
   end
 
   def log_create
-    log_change('create') do |log|
-      log.fill_properties('old', nil, nil)
-      log.update_to self
+    if is_audit_logging_enabled?
+      log_change('create') do |log|
+        log.fill_properties('old', nil, nil)
+        log.update_to self
+      end
     end
   end
 
   def log_update
-    log_change('update') do |log|
-      log.fill_properties('old', etag(@old_attributes), @old_logged_attributes)
-      log.update_to self
+    if is_audit_logging_enabled?
+      log_change('update') do |log|
+        log.fill_properties('old', etag(@old_attributes), @old_logged_attributes)
+        log.update_to self
+      end
     end
   end
 
   def log_destroy
-    log_change('delete') do |log|
-      log.fill_properties('old', etag(@old_attributes), @old_logged_attributes)
-      log.update_to nil
+    if is_audit_logging_enabled?
+      log_change('delete') do |log|
+        log.fill_properties('old', etag(@old_attributes), @old_logged_attributes)
+        log.update_to nil
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed with @tomclegg, the number of audit logs created in our system overwhelms the database with logs and causes things to slow down dramatically.

This PR alllows audit logging to be disabled when the max audit log age is 0 and the audit log delete batch size is more than 0.
