### PR TITLE
limit concurrent slurm commands

### DIFF
--- a/services/crunch-dispatch-slurm/crunch-dispatch-slurm.go
+++ b/services/crunch-dispatch-slurm/crunch-dispatch-slurm.go
@@ -159,7 +159,7 @@ func (disp *Dispatcher) setup() {
 	}
 	arv.Retries = 25
 
-	disp.slurm = &slurmCLI{}
+	disp.slurm = NewSlurmCLI()
 	disp.sqCheck = &SqueueChecker{
 		Period:         time.Duration(disp.PollPeriod),
 		PrioritySpread: disp.PrioritySpread,


### PR DESCRIPTION
use a semaphore channel to limit concurrent sbatch/scancel/scontrol commands to 3.
squeue is already limited to one at a time.

fixes 14110

Arvados-DCO-1.1-Signed-off-by: Joshua C. Randall <jcrandall@alum.mit.edu>