### PR TITLE
Updated API server to allow authentication of users via native webserver authentation.

### DIFF
--- a/services/api/app/controllers/user_sessions_controller.rb
+++ b/services/api/app/controllers/user_sessions_controller.rb
@@ -119,6 +119,22 @@ class UserSessionsController < ApplicationController
   # to save the return_to parameter (if it exists; see the application
   # controller). /auth/joshid bypasses the application controller.
   def login
+    
+    # Added to allow Arvados to use user ID from web server.
+    # This assumes that the user ID is the email address of the user.
+    if Rails.configuration.webserver_login
+      if request.env["REMOTE_USER"] then
+        logger.warn "Using REMOTE_USER from webserver"
+        case Rails.configuration.webserver_login
+        when "email"
+          current_user = User.find_by_email(request.env["REMOTE_USER"])
+        when "username"
+          current_user = User.find_by_username(request.env["REMOTE_USER"])   
+        end
+        Thread.current[:user] = current_user
+      end
+    end
+
     auth_provider = if params[:auth_provider] then "auth_provider=#{CGI.escape(params[:auth_provider])}" else "" end
 
     if current_user and params[:return_to]

--- a/services/api/config/application.default.yml
+++ b/services/api/config/application.default.yml
@@ -43,6 +43,11 @@ common:
   sso_app_secret: ~
   sso_app_id: ~
   sso_provider_url: ~
+  
+  # Set to either email or username to login users using the native webserver authentication
+  # When enabled, have the webserver authenticate users when accessing the following paths
+  # /login and /auth/joshid
+  webserver_login: false
 
   # If this is not false, HTML requests at the API server's root URL
   # are redirected to this location, and it is provided in the text of

--- a/services/api/config/application.yml.example
+++ b/services/api/config/application.yml.example
@@ -24,6 +24,7 @@ production:
   sso_app_secret: ~
   sso_app_id: ~
   sso_provider_url: ~
+  webserver_login: false
   workbench_address: ~
   websocket_address: ~
   #git_repositories_dir: ~
@@ -37,6 +38,7 @@ development:
   sso_app_id: ~
   sso_app_secret: ~
   sso_provider_url: ~
+  webserver_login: false
   workbench_address: ~
   websocket_address: ~
   #git_repositories_dir: ~


### PR DESCRIPTION
For our installation of Arvados, we have modified the API server to allow us to authenticate users using authentication capabilities of the webserver (REMOTE_USER).  We had done this as we had an existing SSO solution for our web applications that used an authentication module for the webserver (Apache).  We have made the modification so that it is optional, i.e. if a user sets webserver_login to email or username the API server would use the value of REMOTE_USER to find the user either by email or username.  By default the value of webserver_login is false and the API server will not use the value of REMOTE_USER.