### PR TITLE
Python 3: only import subprocess32 on py27

### DIFF
--- a/sdk/cwl/arvados_cwl/runner.py
+++ b/sdk/cwl/arvados_cwl/runner.py
@@ -7,12 +7,16 @@ standard_library.install_aliases()
 from future.utils import  viewvalues, viewitems
 
 import os
+import sys
 import urllib.parse
 from functools import partial
 import logging
 import json
-import subprocess32 as subprocess
 from collections import namedtuple
+if sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from io import StringIO
 

--- a/sdk/cwl/setup.py
+++ b/sdk/cwl/setup.py
@@ -40,8 +40,10 @@ setup(name='arvados-cwl-runner',
           'arvados-python-client>=1.3.0.20190205182514',
           'setuptools',
           'ciso8601 >=1.0.6, <2.0.0',
-          'subprocess32>=3.5.1',
       ],
+      extras_require={
+          ':os.name=="posix" and python_version<"3"': ['subprocess32 >= 3.5.1'],
+      },
       data_files=[
           ('share/doc/arvados-cwl-runner', ['LICENSE-2.0.txt', 'README.rst']),
       ],

--- a/sdk/python/arvados/commands/keepdocker.py
+++ b/sdk/python/arvados/commands/keepdocker.py
@@ -10,13 +10,16 @@ import errno
 import json
 import os
 import re
-import subprocess32 as subprocess
 import sys
 import tarfile
 import tempfile
 import shutil
 import _strptime
 import fcntl
+if sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from operator import itemgetter
 from stat import *

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -54,8 +54,10 @@ setup(name='arvados-python-client',
           'ruamel.yaml >=0.15.54, <=0.15.77',
           'setuptools',
           'ws4py >=0.4.2',
-          'subprocess32 >=3.5.1',
       ],
+      extras_require={
+          ':os.name=="posix" and python_version<"3"': ['subprocess32 >= 3.5.1'],
+      },
       classifiers=[
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',


### PR DESCRIPTION
Avoids the need to install and import subprocess32 when working
with any recent Python 3.x version. This helps with bioconda
install since subprocess32 is not built for py3.