### PR TITLE
NumberFormatException fix

### DIFF
--- a/sdk/java-v2/src/main/java/org/arvados/client/logic/collection/FileToken.java
+++ b/sdk/java-v2/src/main/java/org/arvados/client/logic/collection/FileToken.java
@@ -13,7 +13,7 @@ import org.arvados.client.common.Characters;
 public class FileToken {
 
     private int filePosition;
-    private int fileSize;
+    private long fileSize;
     private String fileName;
     private String path;
 
@@ -46,7 +46,7 @@ public class FileToken {
         return this.filePosition;
     }
 
-    public int getFileSize() {
+    public long getFileSize() {
         return this.fileSize;
     }
 

--- a/sdk/java-v2/src/main/java/org/arvados/client/logic/collection/FileToken.java
+++ b/sdk/java-v2/src/main/java/org/arvados/client/logic/collection/FileToken.java
@@ -29,7 +29,7 @@ public class FileToken {
     private void splitFileTokenInfo(String fileTokenInfo) {
         String[] tokenPieces = fileTokenInfo.split(":");
         this.filePosition = Integer.parseInt(tokenPieces[0]);
-        this.fileSize = Integer.parseInt(tokenPieces[1]);
+        this.fileSize = Long.parseLong(tokenPieces[1]);
         this.fileName = tokenPieces[2].replace(Characters.SPACE, " ");
     }
 

--- a/sdk/java-v2/src/main/java/org/arvados/client/logic/keep/FileDownloader.java
+++ b/sdk/java-v2/src/main/java/org/arvados/client/logic/keep/FileDownloader.java
@@ -187,7 +187,7 @@ public class FileDownloader {
         // values for tracking file output streams and matching data chunks with initial files
         int currentDataChunkNumber;
         int bytesDownloadedFromChunk;
-        int bytesToDownload;
+        long bytesToDownload;
         byte[] currentDataChunk;
         boolean remainingDataInChunk;
         final List<KeepLocator> keepLocators;
@@ -199,11 +199,11 @@ public class FileDownloader {
             this.keepLocators = keepLocators;
         }
 
-        private int getBytesToDownload() {
+        private long getBytesToDownload() {
             return bytesToDownload;
         }
 
-        private void setBytesToDownload(int bytesToDownload) {
+        private void setBytesToDownload(long bytesToDownload) {
             this.bytesToDownload = bytesToDownload;
         }
 
@@ -244,7 +244,7 @@ public class FileDownloader {
 
         private void writeDownDataChunkPartially(FileOutputStream fos) throws IOException {
             //write all remaining bytes for this file from current chunk
-            fos.write(currentDataChunk, bytesDownloadedFromChunk, bytesToDownload);
+            fos.write(currentDataChunk, bytesDownloadedFromChunk, (int) bytesToDownload);
             // update number of bytes downloaded from this chunk
             bytesDownloadedFromChunk += bytesToDownload;
             // set remaining data in chunk to true

--- a/sdk/java-v2/src/test/java/org/arvados/client/logic/collection/FileTokenTest.java
+++ b/sdk/java-v2/src/test/java/org/arvados/client/logic/collection/FileTokenTest.java
@@ -15,7 +15,7 @@ public class FileTokenTest {
 
     public static final String FILE_TOKEN_INFO = "0:1024:test-file1";
     public static final int FILE_POSITION = 0;
-    public static final int FILE_LENGTH = 1024;
+    public static final long FILE_LENGTH = 1024L;
     public static final String FILE_NAME = "test-file1";
     public static final String FILE_PATH = "c" + Characters.SLASH;
 


### PR DESCRIPTION
When file size is bigger than Integer.MAX_VALUE we get NumberFormatException in `FileToken::splitFileTokenInfo`