### PR TITLE
Add warning notice that Composer is no longer maintained

### DIFF
--- a/doc/install/install-composer.html.textile.liquid
+++ b/doc/install/install-composer.html.textile.liquid
@@ -11,6 +11,10 @@ SPDX-License-Identifier: CC-BY-SA-3.0
 
 Arvados Composer is a web-based javascript application for building Common Workflow Languge (CWL) Workflows.
 
+{% include 'notebox_begin_warning' %}
+Arvados Composer is currently not being maintained. The instructions on this page are out of date and are therefore not guarenteed to work.
+{% include 'notebox_end' %}
+
 # "Install dependencies":#dependencies
 # "Update config.yml":#update-config
 # "Update Nginx configuration":#update-nginx


### PR DESCRIPTION
Since Arvados Composer is no longer supported / maintained it would help new users to the project to know that the installation instructions are no longer up to date (e.g. the `arvados-composer` package is no longer part of the package managers' repositories). Keeping the installation page up might be useful for anyone who might want to pick this up in the future.