### PR TITLE
Partially remove dev.arvados.org URLs and migrate them to GitHub links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo >&2
 	@echo >&2 "More info:"
 	@echo >&2 "  Installing              --> http://doc.arvados.org/install"
-	@echo >&2 "  Developing/contributing --> https://dev.arvados.org"
+	@echo >&2 "  Developing/contributing --> https://github.com/arvados/arvados"
 	@echo >&2 "  Project home            --> https://arvados.org"
 	@echo >&2
 	@false

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ All participants are expected to abide by the [Arvados Code of Conduct](CODE_OF_
 
 See [CONTRIBUTING](CONTRIBUTING.md) for information about Arvados development and how to contribute to the Arvados project.
 
-The [development road map](https://dev.arvados.org/issues/gantt?utf8=%E2%9C%93&set_filter=1&gantt=1&f%5B%5D=project_id&op%5Bproject_id%5D=%3D&v%5Bproject_id%5D%5B%5D=49&f%5B%5D=&zoom=1) outlines some of the project priorities over the next twelve months.
-
 # Licensing
 
 Arvados is Free Software.  See [COPYING](COPYING) for information about the open source licenses used in Arvados.

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -63,7 +63,7 @@ CONFIGSRC=path Dir with config.yml file containing PostgreSQL section
 
 More information and background:
 
-https://dev.arvados.org/projects/arvados/wiki/Running_tests
+https://github.com/arvados/arvados/blob/main/doc/development/RunningTests.md
 EOF
 
 # First make sure to remove any ARVADOS_ variables from the calling

--- a/doc/admin/upgrading.html.textile.liquid
+++ b/doc/admin/upgrading.html.textile.liquid
@@ -149,7 +149,7 @@ Arvados 3.2 no longer includes the arvbox Docker image and associated tooling. T
 
 If you were using arvbox in demo mode, consider installing on a Debian-based virtual machine with our "single-node Ansible installer":{{ site.baseurl }}/install/install-single-host.html.
 
-If you were using arvbox or @arvados-server install@ for development, we now provide an Ansible playbook to install development dependencies on a Debian-based system. Our "Hacking Prerequisites wiki":https://github.com/arvados/arvados/blob/main/doc/development/Prerequisites.md has instructions for how to use it.
+If you were using arvbox or @arvados-server install@ for development, we now provide an Ansible playbook to install development dependencies on a Debian-based system. Our "Hacking Prerequisites wiki":https://dev.arvados.org/projects/arvados/wiki/Hacking_prerequisites has instructions for how to use it.
 
 h2(#v3_1_2). v3.1.2 (2025-05-27)
 

--- a/doc/admin/upgrading.html.textile.liquid
+++ b/doc/admin/upgrading.html.textile.liquid
@@ -149,7 +149,7 @@ Arvados 3.2 no longer includes the arvbox Docker image and associated tooling. T
 
 If you were using arvbox in demo mode, consider installing on a Debian-based virtual machine with our "single-node Ansible installer":{{ site.baseurl }}/install/install-single-host.html.
 
-If you were using arvbox or @arvados-server install@ for development, we now provide an Ansible playbook to install development dependencies on a Debian-based system. Our "Hacking Prerequisites wiki":https://dev.arvados.org/projects/arvados/wiki/Hacking_prerequisites has instructions for how to use it.
+If you were using arvbox or @arvados-server install@ for development, we now provide an Ansible playbook to install development dependencies on a Debian-based system. Our "Hacking Prerequisites wiki":https://github.com/arvados/arvados/blob/main/doc/development/Prerequisites.md has instructions for how to use it.
 
 h2(#v3_1_2). v3.1.2 (2025-05-27)
 

--- a/doc/index.html.liquid
+++ b/doc/index.html.liquid
@@ -41,7 +41,7 @@ SPDX-License-Identifier: CC-BY-SA-3.0
       <p>Curii Corporation provides managed Arvados installations as well as commercial support for Arvados. Please contact <a href="mailto:info@curii.com">info@curii.com</a> for more information.</p>
 
       <p><strong>Contributing</strong></p>
-      <p>Please visit the <a href="https://dev.arvados.org/projects/arvados/wiki/Wiki#Contributing-and-hacking">developer site</a>. Arvados is 100% free and open source software, check out the code on <a href="https://github.com/arvados/arvados">github</a>.
+      <p>Please visit the <a href="https://github.com/arvados/arvados/tree/main/doc/development">developer documentation</a>. Arvados is 100% free and open source software, check out the code on <a href="https://github.com/arvados/arvados">GitHub</a>.
 
       <p>Arvados is under active development, see the <a href="https://dev.arvados.org/projects/arvados/activity">recent developer activity</a>.
       </p>

--- a/doc/index.html.liquid
+++ b/doc/index.html.liquid
@@ -43,7 +43,7 @@ SPDX-License-Identifier: CC-BY-SA-3.0
       <p><strong>Contributing</strong></p>
       <p>Please visit the <a href="https://github.com/arvados/arvados/tree/main/doc/development">developer documentation</a>. Arvados is 100% free and open source software, check out the code on <a href="https://github.com/arvados/arvados">GitHub</a>.
 
-      <p>Arvados is under active development, see the <a href="https://dev.arvados.org/projects/arvados/activity">recent developer activity</a>.
+      <p>Arvados is under active development, see the <a href="https://github.com/arvados/arvados/pulse">recent developer activity</a>.
       </p>
       <p><strong>License</strong></p>
       <p>Most of Arvados is licensed under the <a href="{{ site.baseurl }}/user/copying/agpl-3.0.html">GNU AGPL v3</a>. The SDKs are licensed under the <a href="{{ site.baseurl }}/user/copying/LICENSE-2.0.html">Apache License 2.0</a> and can be incorporated into proprietary code. See <a href="{{ site.baseurl }}/user/copying/copying.html">Arvados Free Software Licenses</a> for more information.

--- a/doc/install/arvbox.html.textile.liquid
+++ b/doc/install/arvbox.html.textile.liquid
@@ -15,6 +15,6 @@ The Arvados team does not maintain or support arvbox as of Arvados 3.2.0.
 
 If you were using arvbox in demo mode, consider installing on a Debian-based virtual machine with our "single-node Ansible installer":{{ site.baseurl }}/install/install-single-host.html.
 
-If you were using arvbox for development, we now provide an Ansible playbook to install development dependencies on a Debian-based system. Our "Hacking Prerequisites wiki":https://dev.arvados.org/projects/arvados/wiki/Hacking_prerequisites has instructions for how to use it.
+If you were using arvbox for development, we now provide an Ansible playbook to install development dependencies on a Debian-based system. Our "Hacking Prerequisites documentation":https://github.com/arvados/arvados/blob/main/doc/development/Prerequisites.md has instructions for how to use it.
 
 Installing systems with Ansible requires a little more initial setup, but once you've done that, it's easier to keep a system up-to-date: when you want to update a system, you simply re-run the playbook. We think this trade-off lets us provide a better experience to a wider variety of users.

--- a/doc/sdk/go/example.html.textile.liquid
+++ b/doc/sdk/go/example.html.textile.liquid
@@ -78,4 +78,4 @@ You can save this source as a .go file and run it:
 
 <notextile>{% code example_sdk_go as go %}</notextile>
 
-A few more usage examples can be found in the "services/keepproxy":https://dev.arvados.org/projects/arvados/repository/revisions/main/show/services/keepproxy and "sdk/go/keepclient":https://dev.arvados.org/projects/arvados/repository/revisions/main/show/sdk/go/keepclient directories in the arvados source tree.
+A few more usage examples can be found in the "services/keepproxy":https://github.com/arvados/arvados/tree/main/services/keepproxy and "sdk/go/keepclient":https://github.com/arvados/arvados/tree/main/sdk/go/keepclient directories in the arvados source tree.

--- a/doc/user/getting_started/community.html.textile.liquid
+++ b/doc/user/getting_started/community.html.textile.liquid
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CC-BY-SA-3.0
 
 h2. On the web
 
-The Arvados Free Sofware project page is located at "https://arvados.org":https://arvados.org .  The "Arvados Wiki":https://dev.arvados.org/projects/arvados/wiki is a collaborative site for documenting Arvados and provides an overview of the Arvados Platform and Components.
+The Arvados Free Sofware project page is located at "https://arvados.org":https://arvados.org .  The "Arvados GitHub project":https://github.com/arvados/arvados is a collaborative site for improving Arvados and provides an overview of the Arvados Platform and Components.
 
 h2. Forum
 

--- a/services/workbench2/Makefile
+++ b/services/workbench2/Makefile
@@ -44,7 +44,7 @@ help:
 	@echo >&2
 	@echo >&2 "More info:"
 	@echo >&2 "  Installing              --> http://doc.arvados.org/install"
-	@echo >&2 "  Developing/contributing --> https://dev.arvados.org"
+	@echo >&2 "  Developing/contributing --> https://github.com/arvados/arvados"
 	@echo >&2 "  Project home            --> https://arvados.org"
 	@echo >&2
 	@false


### PR DESCRIPTION
In this series of commits, I've changed the URLs referencing the `dev.arvados.org` site to their counterparts on `github.com`.

The revisions under the `doc/` and the main `README.md` are part of public-facing text, and I've adjusted the wording of the URLs' context where appropriate.

The reference to the Gantt chart in `README.md` is simply removed.

Some of these URLs are printed to the CLI help messages (e.g. in `run-tests.sh` and Makefiles), and are simply replaced.

This addresses #365 but see discussions there for further considerations.