### PR TITLE
WIP: arvcli.py help message improvements.

### DIFF
--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -863,12 +863,12 @@ def dispatch(arguments=None):
     # required by the parser. But "method" may be absent, as is in the case of
     # external commands like "ws" or "copy".
     method = getattr(args, "method", "")
+    command_key = f"{args.subcommand} {method}" if method else args.subcommand
 
     # Are we calling an external command?
-    ext_module = cmd_parser.external_command_modules.get(
-        f"{args.subcommand} {method}" if method else args.subcommand
-    )
+    ext_module = cmd_parser.external_command_modules.get(command_key)
     if ext_module is not None:
+        sys.argv[0] = f"arv {command_key}"
         _handle_external_command(ext_module, remaining_args)  # Exits.
 
     # Are we doing an API resource call?
@@ -881,7 +881,7 @@ def dispatch(arguments=None):
             cmd_parser.error(
                 f"unrecognized arguments: {', '.join(remaining_args)}\n"
                 f"Try: {sys.argv[0]} --help\n"
-                f"     {sys.argv[0]} {args.subcommand} {method} --help",
+                f"     {sys.argv[0]} {command_key} --help",
                 with_help=False
             )  # Exits with status 2.
         _handle_resource_method(api_client, resource, args)  # Exits.

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -501,7 +501,22 @@ class YAMLEditingProcess(ObjectEditingProcessBase):
         return obj
 
 
-class ArvCLIArgumentParser(argparse.ArgumentParser):
+class FullHelpOnErrorArgumentParser(argparse.ArgumentParser):
+    """Argument parser subclass that customizes the `error()` method.
+
+    Intended to be used as a base to a parser with complex subparsers, to print
+    more-useful information when a required subcommand is missing.
+    """
+    def error(self, message, with_help=True):
+        if with_help:
+            self.print_help(sys.stderr)
+            print(file=sys.stderr)
+        # XXX: Use of self.prog, undocumented.
+        print(f"{self.prog}: error: {message}", file=sys.stderr)
+        sys.exit(2)
+
+
+class ArvCLIArgumentParser(FullHelpOnErrorArgumentParser):
     """Argument parser for `arv` commands.
     """
     global_args = frozenset((
@@ -553,32 +568,41 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
 
         subparsers = self.add_subparsers(
             dest="subcommand",
-            help="Subcommands",
+            description="Available subcommands and resources",
             required=True,
-            parser_class=functools.partial(
-                argparse.ArgumentParser,
-                add_help=False,
-            )
+            metavar="subcommand",  # Suppress huge list in help message.
+            parser_class=FullHelpOnErrorArgumentParser
         )
 
-        keep_parser = subparsers.add_parser("keep")
+        keep_methods = ["ls", "get", "put", "docker"]
+        keep_parser = subparsers.add_parser(
+            "keep", help="Arvados Keep client", add_help=False,
+            epilog=f"available methods: {', '.join(keep_methods)}"
+        )
         keep_parser.add_argument(
             "method",
-            choices=["ls", "get", "put", "docker"]
+            metavar="METHOD",
+            choices=keep_methods
         )
 
-        ws_parser = subparsers.add_parser("ws")
-        copy_parser = subparsers.add_parser("copy")
+        subparsers.add_parser(
+            "ws", help="Arvados WebSocket client", add_help=False
+        )
+        subparsers.add_parser(
+            "copy",
+            help=(
+                "Copy collection, workflow, or project between Arvados"
+                " instances"
+            ),
+            add_help=False
+        )
 
         self.subparsers = subparsers
         self.resource_dictionary = resource_dictionary
-        self._subparser_index = {}
         self._subcommand_to_resource = {}
 
         self.add_resource_subcommands()
 
-        if "sys" in self._subparser_index:
-            self._subparser_index["sy"] = self._subparser_index["sys"]
         if "sys" in self._subcommand_to_resource:
             self._subcommand_to_resource["sy"] = (
                 self._subcommand_to_resource["sys"]
@@ -614,28 +638,37 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         for resource, resource_schema in self.resource_dictionary.items():
             subcommand = _ArgUtil.singularize_resource(resource)
             self._subcommand_to_resource[subcommand] = resource
+            # XXX: Below, "{resource}" can be a "word" like
+            # "api_client_authorizations" that doesn't read well; consider
+            # retrieving more natural-language-flavored description from the
+            # "schema" portion of the discovery doc?
+            subcommand_summary = f"Resource subcommand for {resource}"
             resource_subparser = self.subparsers.add_parser(
                 subcommand,
+                help=subcommand_summary,
+                description=subcommand_summary,
                 # For backward compatibility with legacy Ruby CLI client.
                 aliases=["sy"] if subcommand == "sys" else []
             )
-            self._subparser_index[subcommand] = resource_subparser
             methods_dict = resource_schema.get("methods")
             if methods_dict:
                 # Create a collection of "sub-subparsers" under the resource
                 # subparser for the methods.
                 method_subparsers = resource_subparser.add_subparsers(
-                    title="Methods",
+                    title="methods",
                     dest="method",
-                    parser_class=argparse.ArgumentParser,
-                    help=f"Methods for subcommand {subcommand}"
+                    parser_class=FullHelpOnErrorArgumentParser,
+                    required=True,
+                    help=f"Methods for subcommand '{subcommand}'"
                 )
                 for method, method_schema in methods_dict.items():
                     # Add each specific method as a (sub-)subparser with its
                     # associated parameters.
+                    method_summary = method_schema.get("description")
                     method_parser = method_subparsers.add_parser(
                         method,
-                        help=method_schema.get("description")
+                        description=method_summary,
+                        help=method_summary
                     )
                     for parameter_names, kwargs in _ArgUtil.get_method_options(
                             method_schema
@@ -841,27 +874,15 @@ def dispatch(arguments=None):
     # Are we doing an API resource call?
     resource = cmd_parser._subcommand_to_resource.get(args.subcommand)
     if resource is not None:
-        # This is to work around an issue with nested subparsers being unable
-        # to show subcommand-level help (while help generation for the
-        # leafmost, method-level subparser works as expected). For example,
-        # "arvcli.py resouce method -h" will be handled by the leafmost parser
-        # first and the code will not reach here if that is the CLI given.
-        # However, "arvcli.py resource -h" is handled manually here.
-        help_wanted = "-h" in remaining_args or "--help" in remaining_args
-        if not method or help_wanted:
-            subparser = cmd_parser._subparser_index[args.subcommand]
-            subparser.print_help(
-                file=(sys.stdout if help_wanted else sys.stderr)
-            )
-            sys.exit(0 if help_wanted else 2)
         # Any further remaining args indicate either malformed or unrecognized
         # global args (e.g. "arvcli.py --bad-arg resource method") or undefined
         # parameters to a valid resouce-method combination.
-        elif remaining_args:
+        if remaining_args:
             cmd_parser.error(
                 f"unrecognized arguments: {', '.join(remaining_args)}\n"
                 f"Try: {sys.argv[0]} --help\n"
-                f"     {sys.argv[0]} {args.subcommand} {method} --help"
+                f"     {sys.argv[0]} {args.subcommand} {method} --help",
+                with_help=False
             )  # Exits with status 2.
         _handle_resource_method(api_client, resource, args)  # Exits.
 

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -58,6 +58,19 @@ def simple_api_client():
         api_client.close()
 
 
+@pytest.fixture
+def run_arvcli(capsys, monkeypatch):
+
+    def the_run(cli_args):
+        monkeypatch.setattr(sys, "argv", [arvcli.__file__, *cli_args])
+        with pytest.raises(SystemExit) as exc:
+            arvcli.dispatch(cli_args)
+        captured = capsys.readouterr()
+        return exc.value.code, captured.out, captured.err
+
+    return the_run
+
+
 def test_global_option_help_followed_by_subcommand():
     """When called as arvcli.py -h [subcommand], the subcommand is ignored,
     the -h option is consumed by the parser, and the help message is printed,
@@ -83,39 +96,30 @@ def test_invalid_subcommand():
     assert exit_status.value.code == 2
 
 
-# Pass-through (sub)commands and their corresponding 'entry point' functions.
-PASSTHROUGH_CMD_FUNCS = [
-    ("keep ls", "arvados.commands.ls.main"),
-    ("keep get", "arvados.commands.get.main"),
-    ("keep put", "arvados.commands.put.main"),
-    ("keep docker", "arvados.commands.keepdocker.main"),
-    ("ws", "arvados.commands.ws.main"),
-    ("copy", "arvados.commands.arv_copy.main")
-]
-
-
-@pytest.mark.parametrize("subcommand,main_func_name", PASSTHROUGH_CMD_FUNCS)
-def test_passthrough_commands_args(subcommand, main_func_name):
+@pytest.mark.parametrize(
+    "subcommand,cmd_mod_name",
+    arvcli.ArvCLIArgumentParser.external_command_modules.items()
+)
+def test_passthrough_commands_args(subcommand, cmd_mod_name, run_arvcli):
     """Test that arbitrary argv ('[...] arvcli.py subcommand --foo bar') to
     arvcli.py gets passed to the underlying subcommand; i.e. the passed-through
-    subcommand's entry function gets called with ["--foo", "bar"].
+    subcommand's `main()` function gets called with ["--foo", "bar"].
     """
-    with mock.patch(main_func_name) as s:
-        with pytest.raises(SystemExit):
-            arvcli.dispatch([*subcommand.split(), "--foo", "bar"])
-        s.assert_called_with(["--foo", "bar"])
+    mock_mod = mock.Mock()
+    with pytest.MonkeyPatch.context() as m:
+        m.setitem(sys.modules, cmd_mod_name, mock_mod)
+        run_arvcli([*subcommand.split(), "--foo", "bar"])
+    mock_mod.main.assert_called_with(["--foo", "bar"])
 
 
-@pytest.mark.parametrize("subcommand,main_func_name", PASSTHROUGH_CMD_FUNCS)
-def test_passthrough_commands_help(subcommand, main_func_name):
-    """Test that the -h flag to a subcommand (as opposed to the main command)
-    gets passed to the underlying script rather than consumed by the main arg
-    parser.
-    """
-    with mock.patch(main_func_name) as s:
-        with pytest.raises(SystemExit):
-            arvcli.dispatch([*subcommand.split(), "-h"])
-        s.assert_called_with(["-h"])
+@pytest.mark.parametrize(
+    "subcommand",
+    arvcli.ArvCLIArgumentParser.external_command_modules.keys()
+)
+def test_passthrough_command_usage_prog_name(subcommand, run_arvcli):
+    exit_code, out, err = run_arvcli([*subcommand.split(), "-h"])
+    assert exit_code == 0
+    assert re.search(f"^usage: arv {subcommand}", out)
 
 
 @pytest.mark.parametrize("plural,singular", (
@@ -316,18 +320,6 @@ class TestArgTypes:
         )
         with pytest.raises(argparse.ArgumentTypeError):
             arvcli._ArgTypes.group_uuid("zzzzz-j7d0g-123456789")
-
-
-@pytest.fixture
-def run_arvcli(capsys):
-
-    def the_run(cli_args):
-        with pytest.raises(SystemExit) as exc:
-            arvcli.dispatch(cli_args)
-        captured = capsys.readouterr()
-        return exc.value.code, captured.out, captured.err
-
-    return the_run
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* For external, "pass-through" commands such as `keep docker`, use `add_parser(add_help=False)` for their subparser instances alone, rather than forcing the "sans-help" parser class on all subparsers via `add_subparsers(parser_class=partial(..., add_help=False))`. This removes the problem for the non-passthrough subcommands by restoring the normal behavior of subparsers.
* Remove the custom workaround for this problem we created ourselves.
* When adding a subparser, populate the `help=` keyword argument, so the help message of its parent command properly displays the subcommands.
* When a subcommand is called without required "sub-subcommands", for example `arvcli.py collection` without any method sub-subcommand, dump the full help showing actual available methods and their summaries, rather than just showing the default message saying `error: the following arguments are required: method`. This is done by a custom subclass of `argparse.ArgumentParser` that modifies `error()` method behavior.
* More consistent error messaging for unrecognized parameter in resource-method call.

TODO: the `%(prog)` part in the usage message shown for external subcommands, such as `arvcli.py keep docker --help` or `arvcli.py keep docker --invalid-parameter`, is incorrect; it says `arvcli.py` but should include the full subcommand.