### PR TITLE
397: Use wrapper under `/usr/local/bin` for source-built Python.

### DIFF
--- a/tools/ansible/roles/arvados_python/tasks/main.yml
+++ b/tools/ansible/roles/arvados_python/tasks/main.yml
@@ -10,13 +10,23 @@
 - ansible.builtin.include_tasks: install_from_source.yml
   when: "not (arvados_dev_from_pkgs or python_stat.stat.exists)"
 
-- name: Add Python commands to PATH
+- name: Set major-minor version fact for Python
+  when: "not arvados_dev_from_pkgs"
+  ansible.builtin.set_fact:
+    arvados_python_major_minor: "python{{ arvados_python_version|regex_search('^[0-9]+\\.[0-9]+\\b') }}"
+
+- name: Add Python wrapper command to PATH
+  when: "not arvados_dev_from_pkgs"
+  become: yes
+  ansible.builtin.template:
+    mode: '0755'
+    src: arvados_python_wrapper.j2
+    dest: "{{ ('/usr/local/bin', arvados_python_major_minor)|path_join }}"
+
+- name: Add 'python3' relative link to Python wrapper command in PATH
   when: "not arvados_dev_from_pkgs"
   become: yes
   ansible.builtin.file:
     state: link
-    src: "{{ (arvados_python_destdir, 'bin', item)|path_join }}"
-    dest: "{{ ('/usr/local/bin', item)|path_join }}"
-  loop:
-    - python3
-    - "python{{ arvados_python_version|regex_search('^[0-9]+\\.[0-9]+\\b') }}"
+    src: "{{ arvados_python_major_minor }}"
+    path: /usr/local/bin/python3

--- a/tools/ansible/roles/arvados_python/templates/arvados_python_wrapper.j2
+++ b/tools/ansible/roles/arvados_python/templates/arvados_python_wrapper.j2
@@ -1,0 +1,7 @@
+{# Copyright (C) The Arvados Authors. All rights reserved.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+ #}
+#!/bin/sh
+### This file is managed by Ansible ###
+exec "{{ (arvados_python_destdir, 'bin', arvados_python_major_minor)|path_join }}" "$@"


### PR DESCRIPTION
397-use-wrapper-for-python3-built-from-source-to-avoid-conflict-with-system-python @ a33b5d8837b5ac9cd383cd3cfb8a7e0e0859af74

https://ci.arvados.org/job/developer-run-tests/5086/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Note that this is more accurately a proposal rather than the implementation for agreed points. The change is essentially to use a shell wrapper that `exec`s the built Python under `/opt`, rather using than a link.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * N/A
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Manual installation of the testing environment using `ansible-playbook`, with Python 3.10.20 (default), 3.13.13, and 3.14.5 (the lattermost requires your fix in the branch `395-detect-venv`)
* The tested code incorporates recent main branch changes.
  * Yes
* New or changed UI/UX has gotten feedback from stakeholders.
  * I'm basically seeking comment from developers -- the stakeholders. The change to developer workflow should be minimal and largely invisible.
* Documentation has been updated.
  * N/A; no visible changes; the developer documentation doesn't require updates.
* Behaves appropriately at the intended scale (describe intended scale).
  * N/A
* Considered backwards and forwards compatibility issues between client and server.
  * N/A
* Follows our "coding standards":https://dev.arvados.org/projects/arvados/wiki/Coding_Standards and "GUI style guidelines.":https://dev.arvados.org/projects/arvados/wiki/Coding_Standards#GUI-Design-Guidelines-Workbench-2
  * New Ansible code tries to follow the style of surrounding/existing code.