### PR TITLE
408: Fix `arvcli config get` help message showing spurious parameters

### DIFF
--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -18,6 +18,7 @@ The `ArvCLIArgumentParser` class, specializing the standard Python
 
 import abc
 import argparse
+from collections.abc import Container, Iterable, Mapping
 from contextlib import AbstractContextManager
 import functools
 import importlib
@@ -29,8 +30,9 @@ import shutil
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
-from typing import Any, Mapping, NoReturn, TextIO
+from typing import Any, NoReturn, Optional, TextIO
 import arvados
+from arvados.api import apiclient_discovery
 import arvados.commands._util as cmd_util
 from ruamel.yaml import YAML, YAMLError
 yaml = YAML(typ="safe", pure=True)
@@ -109,7 +111,10 @@ class _ArgUtil:
         return "--" + parameter_key.replace("_", "-")
 
     @staticmethod
-    def get_method_options(method_schema):
+    def get_method_options(
+        method_schema: Mapping[str, Any],
+        ignored_parameters: Optional[Container[str]] = None
+    ):
         """Generate command-line options, in the form of "-f/--foo", from the
         parameters as defined by the API method schema in the discovery
         document.
@@ -142,8 +147,10 @@ class _ArgUtil:
 
         Arguments:
 
-        * method_schema: dict --- Dict object from the parsed discover document
-          that defines a method.
+        * method_schema: Mapping[str, Any] --- Dict object from the parsed
+          discover document that defines a method.
+        * ignored_parameters: Optional[Container[str]] --- If provided, the
+          parameters that are in `ignored_parameters` will not be processed.
         """
         parameters_schema = method_schema.get("parameters", {}).copy()
         # If the method comes with the "request" field, add another parameter
@@ -162,6 +169,8 @@ class _ArgUtil:
                 }
         argument_key_abbrevs = set("h")  # prevent conflict with "help"
         for parameter_key, parameter_dict in parameters_schema.items():
+            if ignored_parameters and parameter_key in ignored_parameters:
+                continue
             parameter_kwargs = {
                 "required": parameter_dict.get("required", False)
             }
@@ -520,13 +529,12 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         "copy": "arvados.commands.arv_copy"
     }
 
-    def __init__(self, resource_dictionary, **kwargs):
+    def __init__(self, discovery_document: dict[str, str | dict], **kwargs):
         """Arguments:
 
-        * resource dictionary: dict --- Dict containing the resources defined
-          in the discovery document; can be obtained as the
-          `_resourceDesc["resources"]` attribute of an Arvados API client
-          object.
+        * discovery_document: dict --- Dict containing the parsed API discovery
+          document; can be obtained as the `_rootDesc` attribute of an
+          Arvados API client object.
         """
         super().__init__(description="Arvados command line client", **kwargs)
         # Common flags to the main command.
@@ -571,7 +579,17 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         copy_parser = subparsers.add_parser("copy")
 
         self.subparsers = subparsers
-        self.resource_dictionary = resource_dictionary
+        self.discovery_document = discovery_document
+        # Work around googleapiclient's mutation of _rootDesc/_resourceDesc
+        # dicts when a resource is created. For instance, currently (as of
+        # 2026-06-03) "configs.get" resource-method's parameters get mutated at
+        # init time of the API client object (as a side-effect of getting the
+        # default storage classes for its KeepClient object).
+        self._ignored_parameters = frozenset(
+            discovery_document.get("parameters", {}).keys()
+            | apiclient_discovery.STACK_QUERY_PARAMETERS
+        )
+        self.resource_schema = discovery_document.get("resources", {})
         self._subparser_index = {}
         self._subcommand_to_resource = {}
 
@@ -588,8 +606,7 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         # for the "create" subcommand.
         creatable_targets = set()
         for cli_name, resource in self._subcommand_to_resource.items():
-            resource_schema = self.resource_dictionary[resource]
-            if "create" in resource_schema.get("methods", {}):
+            if "create" in self.resource_schema[resource].get("methods", {}):
                 creatable_targets.add(cli_name)
         create_parser = subparsers.add_parser(
             "create", help="Create Arvados object using external editor"
@@ -611,7 +628,7 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         """Add resources as subcommands, their associated methods as
         sub-subcommands, and the parameters associated with each method.
         """
-        for resource, resource_schema in self.resource_dictionary.items():
+        for resource, resource_schema in self.resource_schema.items():
             subcommand = _ArgUtil.singularize_resource(resource)
             self._subcommand_to_resource[subcommand] = resource
             resource_subparser = self.subparsers.add_parser(
@@ -638,7 +655,8 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
                         help=method_schema.get("description")
                     )
                     for parameter_names, kwargs in _ArgUtil.get_method_options(
-                            method_schema
+                        method_schema,
+                        ignored_parameters=self._ignored_parameters
                     ):
                         method_parser.add_argument(*parameter_names, **kwargs)
 
@@ -823,7 +841,7 @@ def _ask_reedit() -> bool | None:
 
 def dispatch(arguments=None):
     api_client = arvados.api("v1")
-    cmd_parser = ArvCLIArgumentParser(api_client._resourceDesc["resources"])
+    cmd_parser = ArvCLIArgumentParser(api_client._rootDesc)
     args, remaining_args = cmd_parser.parse_known_args(arguments)
 
     # There's always args.subcommand if we reach here, because "subcommand" is

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -589,7 +589,7 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
             discovery_document.get("parameters", {}).keys()
             | apiclient_discovery.STACK_QUERY_PARAMETERS
         )
-        self.resource_schema = discovery_document.get("resources", {})
+        self.resource_schemas = discovery_document.get("resources", {})
         self._subparser_index = {}
         self._subcommand_to_resource = {}
 
@@ -606,7 +606,7 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         # for the "create" subcommand.
         creatable_targets = set()
         for cli_name, resource in self._subcommand_to_resource.items():
-            if "create" in self.resource_schema[resource].get("methods", {}):
+            if "create" in self.resource_schemas[resource].get("methods", {}):
                 creatable_targets.add(cli_name)
         create_parser = subparsers.add_parser(
             "create", help="Create Arvados object using external editor"
@@ -628,7 +628,7 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         """Add resources as subcommands, their associated methods as
         sub-subcommands, and the parameters associated with each method.
         """
-        for resource, resource_schema in self.resource_schema.items():
+        for resource, resource_schema in self.resource_schemas.items():
             subcommand = _ArgUtil.singularize_resource(resource)
             self._subcommand_to_resource[subcommand] = resource
             resource_subparser = self.subparsers.add_parser(

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -32,8 +32,8 @@ import sys
 from tempfile import NamedTemporaryFile
 from typing import Any, NoReturn, Optional, TextIO
 import arvados
-from arvados.api import apiclient_discovery
 import arvados.commands._util as cmd_util
+from googleapiclient import discovery
 from ruamel.yaml import YAML, YAMLError
 yaml = YAML(typ="safe", pure=True)
 yaml.default_flow_style = False
@@ -113,7 +113,7 @@ class _ArgUtil:
     @staticmethod
     def get_method_options(
         method_schema: Mapping[str, Any],
-        ignored_parameters: Optional[Container[str]] = None
+        ignored_parameters: Container[str] = ()
     ):
         """Generate command-line options, in the form of "-f/--foo", from the
         parameters as defined by the API method schema in the discovery
@@ -149,8 +149,8 @@ class _ArgUtil:
 
         * method_schema: Mapping[str, Any] --- Dict object from the parsed
           discover document that defines a method.
-        * ignored_parameters: Optional[Container[str]] --- If provided, the
-          parameters that are in `ignored_parameters` will not be processed.
+        * ignored_parameters: Container[str] --- If provided, the parameters
+          that are in `ignored_parameters` will not be processed.
         """
         parameters_schema = method_schema.get("parameters", {}).copy()
         # If the method comes with the "request" field, add another parameter
@@ -169,7 +169,7 @@ class _ArgUtil:
                 }
         argument_key_abbrevs = set("h")  # prevent conflict with "help"
         for parameter_key, parameter_dict in parameters_schema.items():
-            if ignored_parameters and parameter_key in ignored_parameters:
+            if parameter_key in ignored_parameters:
                 continue
             parameter_kwargs = {
                 "required": parameter_dict.get("required", False)
@@ -587,7 +587,7 @@ class ArvCLIArgumentParser(argparse.ArgumentParser):
         # default storage classes for its KeepClient object).
         self._ignored_parameters = frozenset(
             discovery_document.get("parameters", {}).keys()
-            | apiclient_discovery.STACK_QUERY_PARAMETERS
+            | discovery.STACK_QUERY_PARAMETERS
         )
         self.resource_schemas = discovery_document.get("resources", {})
         self._subparser_index = {}

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -195,7 +195,22 @@ def test_get_method_options():
                 "required": False,
                 "description": "help-filters.",
                 "location": "query"
-            }
+            },
+            # Based on parameters from top-level "parameters" key.
+            "alt": {
+                "type": "string",
+                "description": "Data format for the response.",
+                "default": "json",
+                "enum": [
+                    "json"
+                ],
+                "enumDescriptions": [
+                    "Responses with Content-Type of application/json"
+                ],
+                "location": "query"
+            },
+            # Based on googleapiclient's injection of "stack query parameters".
+            "pp": {"type": "string", "location": "query"}
         },
         "request": {
             "required": True,
@@ -288,34 +303,10 @@ def test_get_method_options():
         )
     ]
     assert list(
-        arvcli._ArgUtil.get_method_options(input_method_schema)
-    ) == output
-
-def test_get_method_options_ignored_parameters():
-    input_method_schema = {
-        "parameters": {
-            # Based on parameters from top-level "parameters" key.
-            "alt": {
-                "type": "string",
-                "description": "Data format for the response.",
-                "default": "json",
-                "enum": [
-                    "json"
-                ],
-                "enumDescriptions": [
-                    "Responses with Content-Type of application/json"
-                ],
-                "location": "query"
-            },
-            # Based on googleapiclient's injection of "stack query parameters".
-            "pp": {"type": "string", "location": "query"}
-        }
-    }
-    assert list(
         arvcli._ArgUtil.get_method_options(
             input_method_schema, ignored_parameters=("alt", "pp")
         )
-    ) == []
+    ) == output
 
 
 class TestArgTypes:

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -58,6 +58,11 @@ def simple_api_client():
         api_client.close()
 
 
+@pytest.fixture
+def discovery_document(simple_api_client):
+    yield simple_api_client._rootDesc
+
+
 def test_global_option_help_followed_by_subcommand():
     """When called as arvcli.py -h [subcommand], the subcommand is ignored,
     the -h option is consumed by the parser, and the help message is printed,
@@ -129,11 +134,9 @@ def test_singularizer(plural, singular):
     assert arvcli._ArgUtil.singularize_resource(plural) == singular
 
 
-def test_cli_parser_has_singular_plural_mapping(simple_api_client):
-    cmd_parser = arvcli.ArvCLIArgumentParser(
-        simple_api_client._resourceDesc["resources"]
-    )
-    for resource in cmd_parser.resource_dictionary.keys():
+def test_cli_parser_has_singular_plural_mapping(discovery_document):
+    cmd_parser = arvcli.ArvCLIArgumentParser(discovery_document)
+    for resource in cmd_parser.resource_schema:
         k = arvcli._ArgUtil.singularize_resource(resource)
         assert cmd_parser._subcommand_to_resource[k] == resource
     assert cmd_parser._subcommand_to_resource["sy"] == cmd_parser._subcommand_to_resource["sys"]
@@ -287,6 +290,32 @@ def test_get_method_options():
     assert list(
         arvcli._ArgUtil.get_method_options(input_method_schema)
     ) == output
+
+def test_get_method_options_ignored_parameters():
+    input_method_schema = {
+        "parameters": {
+            # Based on parameters from top-level "parameters" key.
+            "alt": {
+                "type": "string",
+                "description": "Data format for the response.",
+                "default": "json",
+                "enum": [
+                    "json"
+                ],
+                "enumDescriptions": [
+                    "Responses with Content-Type of application/json"
+                ],
+                "location": "query"
+            },
+            # Based on googleapiclient's injection of "stack query parameters".
+            "pp": {"type": "string", "location": "query"}
+        }
+    }
+    assert list(
+        arvcli._ArgUtil.get_method_options(
+            input_method_schema, ignored_parameters=("alt", "pp")
+        )
+    ) == []
 
 
 class TestArgTypes:
@@ -611,7 +640,7 @@ def test_uuid_output_with_list_items_having_no_uuid(run_arvcli):
 
 
 class TestDefaultValuesForAPICalls:
-    resources = arvados.api("v1")._resourceDesc["resources"]
+    resources = arvados.api("v1")._rootDesc["resources"]
 
     @classmethod
     def get_default(cls, resource, method, parameter):
@@ -641,6 +670,12 @@ class TestConfigGet:
     def test_config_get(self, run_arvcli):
         exit_code, out, err = run_arvcli(["config", "get"])
         assert exit_code == 0
+
+    def test_config_get_help(self, run_arvcli):
+        exit_code, out, err = run_arvcli(["config", "get", "-h"])
+        assert exit_code == 0
+        out_lines = out.splitlines()
+        assert re.match(r"^usage: \S+ config get \[-h\]$", out_lines[0])
 
     def test_config_get_uuid(self, run_arvcli):
         exit_code, out, err = run_arvcli(["--format", "uuid", "config", "get"])

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -136,7 +136,7 @@ def test_singularizer(plural, singular):
 
 def test_cli_parser_has_singular_plural_mapping(discovery_document):
     cmd_parser = arvcli.ArvCLIArgumentParser(discovery_document)
-    for resource in cmd_parser.resource_schema:
+    for resource in cmd_parser.resource_schemas:
         k = arvcli._ArgUtil.singularize_resource(resource)
         assert cmd_parser._subcommand_to_resource[k] == resource
     assert cmd_parser._subcommand_to_resource["sy"] == cmd_parser._subcommand_to_resource["sys"]


### PR DESCRIPTION
`408-fix-arvcli-config-get-spurious-parameters` @ d9c5a1b314681f8f8350e39e30325feacdab1a1d

https://ci.arvados.org/job/developer-run-tests/5091/ (crunchrun intermittent failure affecting the tests but is unrelated)

Fixes #408.

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Implemented the "parameter ignore-list" idea suggested by myself.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * N/A
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Yes for auto testing
  * Manual testing was done to ensure the output of `-h` with various resource-method combos look alright (notably `config get`).
* The tested code incorporates recent main branch changes.
  * Yes
* New or changed UI/UX has gotten feedback from stakeholders.
  * N/A
* Documentation has been updated.
  * N/A
* Behaves appropriately at the intended scale (describe intended scale).
  * N/A
* Considered backwards and forwards compatibility issues between client and server.
  * At the layer of the CLI client, there should be little to worry about client/server compatibility, as we still follow the principle of discovery-based API.
  * A related issue is the compatibility of the "official" Google-API client with the Arvados "Google-esque" API. Behavior of the `googleapiclient` package may include Google-specific quirks and it'll be worthwhile to explore how to minimize our exposure.
* Follows our "coding standards":https://dev.arvados.org/projects/arvados/wiki/Coding_Standards and "GUI style guidelines.":https://dev.arvados.org/projects/arvados/wiki/Coding_Standards#GUI-Design-Guidelines-Workbench-2
  * Yes