### PR TITLE
420: "arv get" subcommand

### DIFF
--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -966,7 +966,8 @@ def _handle_external_editor_command(api_client, parser, args) -> NoReturn:
             api_client, parser, args
         )
         if status != 0:
-            print("Error: {obj_or_msg}", file=sys.stderr)
+            # FIXME: Not yet convered by test.
+            print(f"Error: {obj_or_msg}", file=sys.stderr)
             sys.exit(status)
         # Tempfile name resembling
         # "collection-clstr-4zz18-{15chars}-{random}.{json|yml}".
@@ -1089,8 +1090,9 @@ def _ask_reedit() -> bool | None:
 def _handle_get_subcommand(api_client, parser, args) -> NoReturn:
     status, obj_or_msg = _get_obj_by_uuid_info(api_client, parser, args)
     if status != 0:
+        # FIXME: Not yet convered by test.
         # "obj_or_msg" is a message.
-        print("Error: {obj_or_msg}", file=sys.stderr)
+        print(f"Error: {obj_or_msg}", file=sys.stderr)
     else:
         # "obj_or_msg" is a real Arvados object.
         match args.format:

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -1146,7 +1146,8 @@ def dispatch(arguments=None):
             cmd_parser.error(
                 "--format=uuid or -s option is not supported when creating or"
                 " editing Arvados objects with external editor. Please"
-                " choose --format=json (default) or --format=yaml."
+                " choose --format=json (default) or --format=yaml.",
+                with_help=False
             )  # Exits with status 2.
         _handle_external_editor_command(api_client, cmd_parser, args)  # Exits.
 
@@ -1156,7 +1157,8 @@ def dispatch(arguments=None):
             cmd_parser.error(
                 "--format=uuid or -s option is not supported for the 'arv get'"
                 " command. Please choose --format=json (default) or"
-                " --format=yaml."
+                " --format=yaml.",
+                with_help=False
             )  # Exits with status 2.
         _handle_get_subcommand(api_client, cmd_parser, args)  # Exits.
 

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -1064,10 +1064,6 @@ def _handle_external_editor_command(api_client, parser, args) -> NoReturn:
     # End of the NoReturn function.
 
 
-def _handle_get_subcommand(api_client, parser, args) -> NoReturn:
-    pass
-
-
 def _ask_reedit() -> bool | None:
     """Ask the user if they'd like to continue editing. Returns True for "yes"
     (default, applies also when the user types in a blank newline), False for
@@ -1088,6 +1084,28 @@ def _ask_reedit() -> bool | None:
             return False
         case _:
             return None
+
+
+def _handle_get_subcommand(api_client, parser, args) -> NoReturn:
+    status, obj_or_msg = _get_obj_by_uuid_info(api_client, parser, args)
+    if status != 0:
+        # "obj_or_msg" is a message.
+        print("Error: {obj_or_msg}", file=sys.stderr)
+    else:
+        # "obj_or_msg" is a real Arvados object.
+        match args.format:
+            case "json":
+                json.dump(obj_or_msg, sys.stdout, indent=1)
+                print()
+            case "yaml":
+                yaml.dump(obj_or_msg, sys.stdout)
+            case _:
+                # This must not happen, as "--format=uuid" is an invalid global
+                # option value for "get" subcommand.
+                raise RuntimeError(
+                    f"Error: unexpected value for format option: {args.format}"
+                )
+    sys.exit(status)
 
 
 def dispatch(arguments=None):
@@ -1131,6 +1149,16 @@ def dispatch(arguments=None):
                 " choose --format=json (default) or --format=yaml."
             )  # Exits with status 2.
         _handle_external_editor_command(api_client, cmd_parser, args)  # Exits.
+
+    # Are we running "arv get"?
+    if args.subcommand == "get":
+        if args.format == "uuid":
+            cmd_parser.error(
+                "--format=uuid or -s option is not supported for the 'arv get'"
+                " command. Please choose --format=json (default) or"
+                " --format=yaml."
+            )  # Exits with status 2.
+        _handle_get_subcommand(api_client, cmd_parser, args)  # Exits.
 
     # NOTE: The code immediately below is not reachable.
     raise RuntimeError("Unexpected arguments: {arguments!r}")

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -695,7 +695,15 @@ class ArvCLIArgumentParser(FullHelpOnErrorArgumentParser):
                 self._subcommand_to_resource["sys"]
             )
 
+        self.uuid_parser = functools.partial(
+            _ArgTypes.UUIDInfo.parse,
+            _ArgUtil.make_uuid_to_resource_map(
+                self.discovery_document.get("schemas", {})
+            )
+        )
+
         self.add_editor_subcommands()
+        self.add_get_subcommand()
 
     def add_resource_subcommands(self):
         """Add resources as subcommands, their associated methods as
@@ -766,24 +774,36 @@ class ArvCLIArgumentParser(FullHelpOnErrorArgumentParser):
             help="UUID of the project in which to create the resource"
         )
 
-        self.uuid_type_map = _ArgUtil.make_uuid_to_resource_map(
-            self.discovery_document.get("schemas", {})
-        )
-
         edit_parser = self.subparsers.add_parser(
             "edit", help="Edit Arvados object using external editor"
         )
         edit_parser.add_argument(
-            "uuid_info", help="UUID of the object to be edited",
-            metavar="UUID",
-            type=functools.partial(
-                _ArgTypes.UUIDInfo.parse, self.uuid_type_map
-            )
+            "uuid_info",
+            help="UUID of the object to be edited", metavar="UUID",
+            type=self.uuid_parser
         )
         edit_parser.add_argument(
             "fields", nargs="*",
             type=str.lower,  # "type" applies to individual items.
             help="Fields to be edited (case-insensitive)"
+        )
+
+    def add_get_subcommand(self):
+        get_parser = self.subparsers.add_parser(
+            "get", help=(
+                "Fetch the specified Arvados object, select the specified"
+                " fields, and print a text representation"
+            )
+        )
+        get_parser.add_argument(
+            "uuid_info",
+            help="UUID of the object to be fetched", metavar="UUID",
+            type=self.uuid_parser
+        )
+        get_parser.add_argument(
+            "fields", nargs="*",
+            type=str.lower,
+            help="Fields to be fetched (case-insensitive)"
         )
 
 
@@ -892,13 +912,11 @@ def _select_fields(
     return {k: src[k] for k in fields} or src
 
 
-def _prepare_initial_object_to_edit(
-    api_client, parser, args
-) -> tuple[int, dict | str]:
-    """Obtain the initial object for the "arv edit" subcommand, based on the
-    commandline args and the current API client & CLI parser instances. If the
-    "fields" argument (`args.fields`) is provided, only those fields that are
-    specified are returned.
+def _get_obj_by_uuid_info(api_client, parser, args) -> tuple[int, dict | str]:
+    """Obtain the object for the "get" subcommand and the initial object for
+    the "arv edit" subcommand, based on the commandline args and the current
+    API client & CLI parser instances. If the "fields" argument (`args.fields`)
+    is provided, only those fields that are specified are returned.
 
     Return value:
 
@@ -944,7 +962,7 @@ def _handle_external_editor_command(api_client, parser, args) -> NoReturn:
         # Tempfile name resembling "new-collection-{random}.{json|yml}".
         prefix = f"new-{args.target_resource}"
     else:
-        status, obj_or_msg = _prepare_initial_object_to_edit(
+        status, obj_or_msg = _get_obj_by_uuid_info(
             api_client, parser, args
         )
         if status != 0:
@@ -1044,6 +1062,10 @@ def _handle_external_editor_command(api_client, parser, args) -> NoReturn:
             # End of the editing loop.
         sys.exit(api_call_status)
     # End of the NoReturn function.
+
+
+def _handle_get_subcommand(api_client, parser, args) -> NoReturn:
+    pass
 
 
 def _ask_reedit() -> bool | None:

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -32,10 +32,14 @@ import subprocess
 import sys
 from tempfile import NamedTemporaryFile
 from typing import Any, NoReturn, TextIO
-import arvados
-import arvados.commands._util as cmd_util
+
 from googleapiclient import discovery
 from ruamel.yaml import YAML, YAMLError
+
+import arvados
+import arvados.commands._util as cmd_util
+
+
 yaml = YAML(typ="safe", pure=True)
 yaml.default_flow_style = False
 

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -143,8 +143,8 @@ class _ArgUtil:
 
         Arguments:
 
-        * parameter_key: str -- Parameter key in the form as they appear in the
-          discovery document, typically like `foo_bar`.
+        * parameter_key: str --- Parameter key in the form as they appear in
+          the discovery document, typically like `foo_bar`.
         """
         return "--" + parameter_key.replace("_", "-")
 

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -966,7 +966,6 @@ def _handle_external_editor_command(api_client, parser, args) -> NoReturn:
             api_client, parser, args
         )
         if status != 0:
-            # FIXME: Not yet convered by test.
             print(f"Error: {obj_or_msg}", file=sys.stderr)
             sys.exit(status)
         # Tempfile name resembling
@@ -1090,7 +1089,6 @@ def _ask_reedit() -> bool | None:
 def _handle_get_subcommand(api_client, parser, args) -> NoReturn:
     status, obj_or_msg = _get_obj_by_uuid_info(api_client, parser, args)
     if status != 0:
-        # FIXME: Not yet convered by test.
         # "obj_or_msg" is a message.
         print(f"Error: {obj_or_msg}", file=sys.stderr)
     else:

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1290,3 +1290,18 @@ class TestEditingSubcommands:
         new_obj = json.loads(out)
         assert new_obj["uuid"] == uuid
         assert new_obj["description"] == new_desc
+
+
+class TestGetSubcommand:
+
+    def test_valid_object_no_fields(self, run_arvcli):
+        fx = run_test_server.fixture("authorized_keys")["active"]
+
+        exit_code, out, err = run_arvcli(["get", fx["uuid"]])
+
+        assert exit_code == 0
+        assert not err
+        result = json.loads(out)
+        assert result
+        for k, expected_v in fx.items():
+            assert result[k] == expected_v

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1227,7 +1227,9 @@ class TestEditingSubcommands:
         old_obj = run_test_server.fixture("collections")[
             "collection_owned_by_active"
         ]
-        for k in ("created_at", "modified_at", "updated_at"):
+        if "updated_at" in old_obj:
+            del old_obj["updated_at"]
+        for k in ("created_at", "modified_at"):
             old_obj[k] = dump_datetime(old_obj[k])
         edited_obj = old_obj.copy()
         edited_obj["name"] += "_edited"

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -991,6 +991,11 @@ def test_create_subcommad_s_option(setup_editor, run_arvcli):
     assert not sr.called
 
 
+# This UUID is pro-forma valid (as a collection) but will not match any object
+# on the test server because the cluster-id part doesn't match.
+NOT_FOUND_UUID = "xyzzy-4zz18-12345abcde67890"
+
+
 class TestGetObjByUUIDInfo:
     @pytest.fixture
     def parser(self, discovery_document):
@@ -1005,11 +1010,7 @@ class TestGetObjByUUIDInfo:
         assert arvcli._select_fields(src, fields) == expected
 
     def test_no_such_uuid(self, simple_api_client, parser):
-        uuid = run_test_server.fixture("groups")["aproject"]["uuid"]
-        uuid_list = uuid.split("-")
-        # Make sure the uuid doesn't match by changing its cluster-id part.
-        uuid_list[0] = "xyzzy"
-        args = parser.parse_args(["edit", "-".join(uuid_list)])
+        args = parser.parse_args(["edit", NOT_FOUND_UUID])
         status, value = arvcli._get_obj_by_uuid_info(
             simple_api_client, parser, args
         )
@@ -1092,6 +1093,7 @@ def builtins_input_patched(*args, **kwargs):
 
 
 class TestEditingSubcommands:
+
     @classmethod
     def teardown_class(self):
         run_test_server.reset()
@@ -1211,6 +1213,11 @@ class TestEditingSubcommands:
         exit_code, out, err = run_arvcli(["edit", TestArgTypes.bad_uuid])
         assert exit_code == 2
 
+    def test_edit_non_existent_object(self, run_arvcli):
+        exit_code, out, err = run_arvcli(["edit", NOT_FOUND_UUID])
+        assert exit_code == 1
+        assert "not found" in err.lower()
+
     @pytest.mark.usefixtures("reset_test_server_db")
     def test_edit_collection_name(
             self, simple_api_client, setup_editor, run_arvcli
@@ -1294,7 +1301,7 @@ class TestEditingSubcommands:
 
 class TestGetSubcommand:
 
-    def test_valid_object_no_fields(self, run_arvcli):
+    def test_get_valid_object_no_fields(self, run_arvcli):
         fx = run_test_server.fixture("authorized_keys")["active"]
 
         exit_code, out, err = run_arvcli(["get", fx["uuid"]])
@@ -1305,3 +1312,10 @@ class TestGetSubcommand:
         assert result
         for k, expected_v in fx.items():
             assert result[k] == expected_v
+
+    def test_get_non_existent_uuid(self, run_arvcli):
+        exit_code, out, err = run_arvcli(["get", NOT_FOUND_UUID])
+
+        assert exit_code == 1
+        assert not out
+        assert "not found" in err.lower()

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1119,8 +1119,8 @@ class TestEditingSubcommands:
 
         assert exit_code == 0
         result = format_case.loads(out)
-        for k in new_project.keys():
-            assert new_project[k] == result[k]
+        for k in new_project:
+            assert result[k] == new_project[k]
 
     @pytest.mark.usefixtures("reset_test_server_db")
     def test_create_in_project_yaml(
@@ -1142,8 +1142,8 @@ class TestEditingSubcommands:
         assert exit_code == 0
         result = yaml.load(out)
         assert result["owner_uuid"] == parent_proj["uuid"]
-        for k in new_project.keys():
-            assert new_project[k] == result[k]
+        for k in new_project:
+            assert result[k] == new_project[k]
 
     @pytest.mark.usefixtures("reset_test_server_db")
     @pytest.mark.parametrize("format_case", FORMAT_CASES)
@@ -1168,8 +1168,8 @@ class TestEditingSubcommands:
         assert exit_code == 0
         assert err
         result = format_case.loads(out)
-        for k in new_project.keys():
-            assert new_project[k] == result[k]
+        for k in new_project:
+            assert result[k] == new_project[k]
 
     def test_edit_process_loops_and_exits_when_abandoned_by_blank_file(
         self, setup_editor, run_arvcli, new_project
@@ -1339,8 +1339,8 @@ class TestGetSubcommand:
         assert not err
         result = json.loads(out)
         assert tuple(result) == fields  # Ordering as user specified.
-        for k, v in result.items():
-            assert fx[k] == v
+        for k in result:
+            assert result[k] == fx[k]
 
     def test_get_invalid_fields(self, run_arvcli):
         uuid = run_test_server.fixture("groups")["aproject"]["uuid"]

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1301,14 +1301,17 @@ class TestEditingSubcommands:
 
 class TestGetSubcommand:
 
-    def test_get_valid_object_no_fields(self, run_arvcli):
+    @pytest.mark.parametrize("format_case", FORMAT_CASES)
+    def test_get_valid_object_no_fields(self, format_case, run_arvcli):
         fx = run_test_server.fixture("authorized_keys")["active"]
 
-        exit_code, out, err = run_arvcli(["get", fx["uuid"]])
+        exit_code, out, err = run_arvcli([
+            "-f", format_case.format, "get", fx["uuid"]
+        ])
 
         assert exit_code == 0
         assert not err
-        result = json.loads(out)
+        result = format_case.loads(out)
         assert result
         for k, expected_v in fx.items():
             assert result[k] == expected_v
@@ -1319,3 +1322,48 @@ class TestGetSubcommand:
         assert exit_code == 1
         assert not out
         assert "not found" in err.lower()
+
+    def test_get_valid_object_valid_fields(self, run_arvcli):
+        fx = run_test_server.fixture("collections")[
+            "collection_owned_by_active"
+        ]
+
+        fields = ("portable_data_hash", "name", "owner_uuid")
+        exit_code, out, err = run_arvcli(["get", fx["uuid"], *fields])
+
+        assert exit_code == 0
+        assert not err
+        result = json.loads(out)
+        assert tuple(result) == fields  # Ordering as user specified.
+        for k, v in result.items():
+            assert fx[k] == v
+
+    def test_get_invalid_fields(self, run_arvcli):
+        uuid = run_test_server.fixture("groups")["aproject"]["uuid"]
+        # None of the following are valid fields for a group.
+        invalid_fields = ["foo", "bar", ""]
+
+        exit_code, out, err = run_arvcli(["get", uuid, *invalid_fields])
+
+        assert exit_code == 2
+        assert not out
+        assert "invalid fields for resource 'group': 'foo', 'bar', ''" in err.lower()
+
+    def test_get_valid_and_invalid_fields(self, run_arvcli):
+        uuid = run_test_server.fixture("groups")["aproject"]["uuid"]
+
+        exit_code, out, err = run_arvcli([
+            "get",
+            uuid,
+            "name",  # Valid field.
+            "foo"  # Invalid field.
+        ])
+        assert exit_code == 2
+        assert not out
+        assert "invalid fields for resource 'group': 'foo'" in err.lower()
+
+    def test_get_help(self, run_arvcli):
+        exit_code, out, err = run_arvcli(["get", "-h"])
+
+        assert exit_code == 0
+        assert not err

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1212,6 +1212,8 @@ class TestEditingSubcommands:
     def test_edit_malfomed_type_code_in_uuid(self, run_arvcli):
         exit_code, out, err = run_arvcli(["edit", TestArgTypes.bad_uuid])
         assert exit_code == 2
+        assert not out
+        assert f"Invalid object type code {TestArgTypes.bad_type!r} in Arvados object UUID {TestArgTypes.bad_uuid}:" in err
 
     def test_edit_non_existent_object(self, run_arvcli):
         exit_code, out, err = run_arvcli(["edit", NOT_FOUND_UUID])

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -991,7 +991,7 @@ def test_create_subcommad_s_option(setup_editor, run_arvcli):
     assert not sr.called
 
 
-class TestPrepareInitialObjectToEdit:
+class TestGetObjByUUIDInfo:
     @pytest.fixture
     def parser(self, discovery_document):
         yield arvcli.ArvCLIArgumentParser(discovery_document)
@@ -1010,7 +1010,7 @@ class TestPrepareInitialObjectToEdit:
         # Make sure the uuid doesn't match by changing its cluster-id part.
         uuid_list[0] = "xyzzy"
         args = parser.parse_args(["edit", "-".join(uuid_list)])
-        status, value = arvcli._prepare_initial_object_to_edit(
+        status, value = arvcli._get_obj_by_uuid_info(
             simple_api_client, parser, args
         )
         assert status == 1
@@ -1021,7 +1021,7 @@ class TestPrepareInitialObjectToEdit:
         # None of the following are valid fields for a group.
         invalid_fields = ["foo", "bar", ""]
         args = parser.parse_args(["edit", uuid, *invalid_fields])
-        status, value = arvcli._prepare_initial_object_to_edit(
+        status, value = arvcli._get_obj_by_uuid_info(
             simple_api_client, parser, args
         )
         assert status == 2

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1362,6 +1362,15 @@ class TestGetSubcommand:
         assert not out
         assert "invalid fields for resource 'group': 'foo'" in err.lower()
 
+    def test_get_format_is_uuid(self, run_arvcli):
+        uuid = run_test_server.fixture("groups")["aproject"]["uuid"]
+
+        exit_code, out, err = run_arvcli(["-s", "get", uuid])
+
+        assert exit_code == 2
+        assert not out
+        assert "--format=uuid or -s option is not supported" in err
+
     def test_get_help(self, run_arvcli):
         exit_code, out, err = run_arvcli(["get", "-h"])
 


### PR DESCRIPTION
`420-arv-get-subcommand` @ e935d6676552d1654d5a84954c37da53d45a0667

https://ci.arvados.org/job/developer-run-tests/5100/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * _Yes_; due to similarities between the existing "arv edit" command and "arv get", we did a bit of DRYing-up in the main parser class.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Automated tests: yes, mostly (there's a most-likely unrelated, and intermittent, test failure in `lib/dispatchcloud/worker` that needs further investigation; I haven't been able to reproduce it locally)
  * Manual tests: running the script manually to check for error and help messages.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_; a separate major ticket is in place; the help messages have been updated though.
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _Yes_; we've been following the principle that resource operations are discovery-based.
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_

I've also included some minor refactoring, as well as testing fixes (fixing insufficient checking of results, increasing coverage, etc.), mostly because the significant overlap of "arv edit" and "arv get" in both concept and code; as I work on "arv get" I get to see better how "arv edit" tests can be improved.

Closes #420.