### PR TITLE
432: Python client commands exit consistently

### DIFF
--- a/sdk/python/arvados/commands/arv_copy.py
+++ b/sdk/python/arvados/commands/arv_copy.py
@@ -221,26 +221,26 @@ administrator privileges on the destination cluster to create collections.
             abort("cannot copy object {} of type {}".format(args.object_uuid, t))
     except Exception as e:
         logger.error("%s", e, exc_info=args.verbose)
-        exit(1)
+        sys.exit(1)
 
     if not result:
-        exit(1)
+        sys.exit(1)
 
     # If no exception was thrown and the response does not have an
     # error_token field, presume success
     if result is None or 'error_token' in result or 'uuid' not in result:
         if result:
             logger.error("API server returned an error result: {}".format(result))
-        exit(1)
+        sys.exit(1)
 
     print(result['uuid'])
 
     if result.get('partial_error'):
         logger.warning("Warning: created copy with uuid {} but failed to copy some items: {}".format(result['uuid'], result['partial_error']))
-        exit(1)
+        sys.exit(1)
 
     logger.info("Success: created copy with uuid {}".format(result['uuid']))
-    exit(0)
+    sys.exit(0)
 
 def set_src_owner_uuid(resource, uuid, args):
     global src_owner_uuid
@@ -994,7 +994,7 @@ def copy_from_url(url, src, dst, args):
 
 def abort(msg, code=1):
     logger.info("arv-copy: %s", msg)
-    exit(code)
+    sys.exit(code)
 
 
 # Code for reporting on the progress of a collection upload.

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -817,7 +817,10 @@ def _handle_external_command(module_name: str, args: list[str]) -> NoReturn:
     return value as the exit status code.
     """
     external_mod = importlib.import_module(module_name)
-    sys.exit(external_mod.main(args))
+    external_mod.main(args)  # Exits.
+    raise RuntimeError(
+        f"Error: {module_name}.main() did not exit when called with {args!r}"
+    )
 
 
 def _format_api_error_msg(err: arvados.errors.ApiError, method_call) -> str:
@@ -1167,7 +1170,7 @@ def dispatch(arguments=None):
         _handle_get_subcommand(api_client, cmd_parser, args)  # Exits.
 
     # NOTE: The code immediately below is not reachable.
-    raise RuntimeError("Unexpected arguments: {arguments!r}")
+    raise RuntimeError(f"Unexpected arguments: {arguments!r}")
 
 
 if __name__ == "__main__":

--- a/sdk/python/arvados/commands/get.py
+++ b/sdk/python/arvados/commands/get.py
@@ -187,17 +187,17 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
                             api_client=api_client, args=args)
             except (IOError, OSError) as error:
                 logger.error("can't write to '{}': {}".format(args.destination, error))
-                return 1
+                sys.exit(1)
             except (arvados.errors.ApiError, arvados.errors.KeepReadError) as error:
                 logger.error("failed to download '{}': {}".format(col_loc, error))
-                return 1
+                sys.exit(1)
             except arvados.errors.ArgumentError as error:
                 if 'Argument to CollectionReader' in str(error):
                     logger.error("error reading collection: {}".format(error))
-                    return 1
+                    sys.exit(1)
                 else:
                     raise
-        return 0
+        sys.exit(0)
 
     try:
         reader = arvados.CollectionReader(
@@ -205,7 +205,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
             keep_client=arvados.keep.KeepClient(block_cache=arvados.keep.KeepBlockCache((args.threads+1)*64 * 1024 * 1024), num_prefetch_threads=args.threads))
     except Exception as error:
         logger.error("failed to read collection: {}".format(error))
-        return 1
+        sys.exit(1)
 
     # Scan the collection. Make an array of (stream, file, local
     # destination filename) tuples, and add up total size to extract.
@@ -221,11 +221,11 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
             # If the user asked for a file and we got a subcollection, error out.
             if get_prefix[-1] != os.sep:
                 logger.error("requested file '{}' is in fact a subcollection. Append a trailing '/' to download it.".format('.' + get_prefix))
-                return 1
+                sys.exit(1)
             # If the user asked stdout as a destination, error out.
             elif args.destination == '-':
                 logger.error("cannot use 'stdout' as destination when downloading multiple files.")
-                return 1
+                sys.exit(1)
             # User asked for a subcollection, and that's what was found. Add up total size
             # to download.
             for s, f in files_in_collection(item):
@@ -235,7 +235,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
                 if (not (args.n or args.f or args.skip_existing) and
                     os.path.exists(dest_path)):
                     logger.error('Local file %s already exists.' % (dest_path,))
-                    return 1
+                    sys.exit(1)
                 todo += [(s, f, dest_path)]
                 todo_bytes += f.size()
         elif isinstance(item, arvados.arvfile.ArvadosFile):
@@ -243,10 +243,10 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
             todo_bytes += item.size()
         else:
             logger.error("'{}' not found.".format('.' + get_prefix))
-            return 1
+            sys.exit(1)
     except (IOError, arvados.errors.NotFoundError) as e:
         logger.error(e)
-        return 1
+        sys.exit(1)
 
     out_bytes = 0
     for s, f, outfilename in todo:
@@ -264,14 +264,14 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
                     # Good thing we looked again: apparently this file wasn't
                     # here yet when we checked earlier.
                     logger.error('Local file %s already exists.' % (outfilename,))
-                    return 1
+                    sys.exit(1)
                 if args.r:
                     pathlib.Path(outfilename).parent.mkdir(parents=True, exist_ok=True)
                 try:
                     outfile = open(outfilename, 'wb')
                 except Exception as error:
                     logger.error('Open(%s) failed: %s' % (outfilename, error))
-                    return 1
+                    sys.exit(1)
         if args.hash:
             digestor = hashlib.new(args.hash)
         try:
@@ -306,7 +306,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr):
 
     if args.progress:
         stderr.write('\n')
-    return 0
+    sys.exit(0)
 
 def files_in_collection(c):
     # Sort first by file type, then alphabetically by file path.

--- a/sdk/python/arvados/commands/keepdocker.py
+++ b/sdk/python/arvados/commands/keepdocker.py
@@ -559,9 +559,13 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr, install_sig_handl
         if args.name is None:
             put_args += ['--name', collection_name]
 
-        coll_uuid = arv_put.main(
+        status, coll_uuid = arv_put.do_put(
             put_args + ['--filename', outfile_name, image_file.name], stdout=stdout,
-            install_sig_handlers=install_sig_handlers).strip()
+            install_sig_handlers=install_sig_handlers)
+        if status == 0:
+            coll_uuid = coll_uuid.strip()
+        else:
+            sys.exit(status)
 
         # Managed properties could be already set
         coll_properties = api.collections().get(uuid=coll_uuid).execute(num_retries=args.retries).get('properties', {})

--- a/sdk/python/arvados/commands/ls.py
+++ b/sdk/python/arvados/commands/ls.py
@@ -60,7 +60,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr, api_client=None, 
             if not (isinstance(reader, arvados.CollectionReader) or
                     isinstance(reader, arvados.collection.Subcollection)):
                 logger.error("'{}' is not a subdirectory".format(get_prefix))
-                return 1
+                sys.exit(1)
         else:
             stream_name = '.'
             reader = cr
@@ -68,7 +68,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr, api_client=None, 
             arvados.errors.ArgumentError,
             arvados.errors.NotFoundError) as error:
         logger.error("error fetching collection: {}".format(error))
-        return 1
+        sys.exit(1)
 
     formatters = []
     if args.s:
@@ -78,7 +78,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr, api_client=None, 
     for f in files_in_collection(reader, stream_name):
         print(*(info_func(f) for info_func in formatters), file=stdout)
 
-    return 0
+    sys.exit(0)
 
 def files_in_collection(c, stream_name='.'):
     # Sort first by file type, then alphabetically by file path.

--- a/sdk/python/arvados/commands/put.py
+++ b/sdk/python/arvados/commands/put.py
@@ -1143,8 +1143,8 @@ def desired_project_uuid(api_client, project_uuid, num_retries):
         raise ValueError("Not a valid project UUID: {}".format(project_uuid))
     return query.execute(num_retries=num_retries)['uuid']
 
-def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
-         install_sig_handlers=True):
+def do_put(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
+           install_sig_handlers=True) -> tuple[int, str | None]:
     global api_client
 
     args = parse_arguments(arguments)
@@ -1153,7 +1153,6 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
         logger.setLevel(logging.WARNING)
     else:
         logger.setLevel(logging.INFO)
-    status = 0
 
     request_id = arvados.util.new_request_id()
 
@@ -1173,7 +1172,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
         # make sure the user provides a complete YYYY-MM-DD date.
         if not re.match(r'^\d{4}(?P<dash>-?)\d{2}?(?P=dash)\d{2}', args.trash_at):
             logger.error("--trash-at argument format invalid, use --help to see examples.")
-            sys.exit(1)
+            return 2, None
         # Check if no time information was provided. In that case, assume end-of-day.
         if re.match(r'^\d{4}(?P<dash>-?)\d{2}?(?P=dash)\d{2}$', args.trash_at):
             args.trash_at += 'T23:59:59'
@@ -1181,7 +1180,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
             trash_at = ciso8601.parse_datetime(args.trash_at)
         except:
             logger.error("--trash-at argument format invalid, use --help to see examples.")
-            sys.exit(1)
+            return 2, None
         else:
             if trash_at.tzinfo is not None:
                 # Timezone aware datetime provided.
@@ -1197,21 +1196,21 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
 
         if trash_at <= datetime.datetime.utcnow():
             logger.error("--trash-at argument must be set in the future")
-            sys.exit(1)
+            return 2, None
     if args.trash_after is not None:
         if args.trash_after < 1:
             logger.error("--trash-after argument must be >= 1")
-            sys.exit(1)
+            return 2, None
         trash_at = datetime.timedelta(seconds=(args.trash_after * 24 * 60 * 60))
 
     # Determine the name to use
     if args.name:
         if args.stream or args.raw:
             logger.error("Cannot use --name with --stream or --raw")
-            sys.exit(1)
+            return 2, None
         elif args.update_collection:
             logger.error("Cannot use --name with --update-collection")
-            sys.exit(1)
+            return 2, None
         collection_name = args.name
     else:
         collection_name = "Saved at {} by {}@{}".format(
@@ -1221,7 +1220,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
 
     if args.project_uuid and (args.stream or args.raw):
         logger.error("Cannot use --project-uuid with --stream or --raw")
-        sys.exit(1)
+        return 2, None
 
     # Determine the parent project
     try:
@@ -1229,7 +1228,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
                                             args.retries)
     except (apiclient_errors.Error, ValueError) as error:
         logger.error(error)
-        sys.exit(1)
+        return 1, None
 
     if args.progress:
         reporter = progress_writer(human_progress)
@@ -1255,14 +1254,14 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
             # Only relative paths patterns allowed
             if p.startswith(os.sep):
                 logger.error("Cannot use absolute paths with --exclude")
-                sys.exit(1)
+                return 2, None
             if os.path.dirname(p):
                 # We don't support of path patterns with '..'
                 p_parts = p.split(os.sep)
                 if '..' in p_parts:
                     logger.error(
                         "Cannot use path patterns that include or '..'")
-                    sys.exit(1)
+                    return 2, None
                 # Path search pattern
                 exclude_paths.append(p)
             else:
@@ -1307,7 +1306,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
         logger.error("\n".join([
             "arv-put: Another process is already uploading this data.",
             "         Use --no-cache if this is really what you want."]))
-        sys.exit(1)
+        return 1, None
     except ResumeCacheInvalidError:
         logger.error("\n".join([
             "arv-put: Resume cache contains invalid signature: it may have expired",
@@ -1316,17 +1315,17 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
             "         --no-resume to start a new resume cache.",
             "         --no-cache to disable resume cache.",
             "         --batch to ignore the resume cache if invalid."]))
-        sys.exit(1)
+        return 1, None
     except (CollectionUpdateError, PathDoesNotExistError) as error:
         logger.error("\n".join([
             "arv-put: %s" % str(error)]))
-        sys.exit(1)
+        return 1, None
     except ArvPutUploadIsPending:
         # Dry run check successful, return proper exit code.
-        sys.exit(2)
+        return 1, None
     except ArvPutUploadNotPending:
         # No files pending for upload
-        sys.exit(0)
+        return 0, None
 
     if not args.dry_run and not args.update_collection and args.resume and writer.bytes_written > 0:
         logger.warning("\n".join([
@@ -1341,7 +1340,7 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
     except (arvados.errors.ApiError, arvados.errors.KeepWriteError) as error:
         logger.error("\n".join([
             "arv-put: %s" % str(error)]))
-        sys.exit(1)
+        return 1, None
 
     if args.progress:  # Print newline to split stderr from stdout for humans.
         logger.info("\n")
@@ -1378,14 +1377,9 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
             logger.error(
                 "arv-put: Error creating Collection on project: {}.".format(
                     error))
-            status = 1
-    else:
-        status = 1
 
     # Print the locator (uuid) of the new collection.
-    if output is None:
-        status = status or 1
-    elif not args.silent:
+    if output is not None and not args.silent:
         stdout.write(output)
         if not output.endswith('\n'):
             stdout.write('\n')
@@ -1393,11 +1387,12 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
     if install_sig_handlers:
         arv_cmd.restore_signal_handlers()
 
-    if status != 0:
-        sys.exit(status)
+    return (0 if output is not None else 1), output
 
-    # Success!
-    return output
+
+def main(*args, **kwargs):
+    status, _ = do_put(*args, **kwargs)
+    sys.exit(status)
 
 
 if __name__ == '__main__':

--- a/sdk/python/bin/arv-get
+++ b/sdk/python/bin/arv-get
@@ -7,4 +7,4 @@ import sys
 
 from arvados.commands.get import main
 
-sys.exit(main(sys.argv[1:]))
+main()

--- a/sdk/python/bin/arv-ls
+++ b/sdk/python/bin/arv-ls
@@ -7,4 +7,4 @@ import sys
 
 from arvados.commands.ls import main
 
-sys.exit(main(sys.argv[1:], sys.stdout, sys.stderr))
+main()

--- a/sdk/python/tests/test_arv_get.py
+++ b/sdk/python/tests/test_arv_get.py
@@ -61,18 +61,23 @@ class ArvadosGetTestCase(run_test_server.TestCaseWithServers,
                 c.portable_data_hash(),
                 c.manifest_text(strip=strip_manifest))
 
-    def run_get(self, args):
-        self.stdout.seek(0, 0)
-        self.stdout.truncate(0)
-        self.stderr.seek(0, 0)
-        self.stderr.truncate(0)
-        return arv_get.main(args, self.stdout, self.stderr)
+    def run_get(self, args, stdout=None, stderr=None):
+        if stdout is None:
+            self.stdout.seek(0, 0)
+            self.stdout.truncate(0)
+            stdout = self.stdout
+        if stderr is None:
+            self.stderr.seek(0, 0)
+            self.stderr.truncate(0)
+            stderr = self.stderr
+        with self.assertRaises(SystemExit) as cm:
+            arv_get.main(args, stdout, stderr)
+        return cm.exception.code
 
     def test_version_argument(self):
         with tutil.redirected_streams(
                 stdout=tutil.StringIO, stderr=tutil.StringIO) as (out, err):
-            with self.assertRaises(SystemExit):
-                self.run_get(['--version'])
+            self.run_get(['--version'])
         self.assertVersionOutput(out, err)
 
     def test_get_single_file(self):
@@ -176,7 +181,7 @@ class ArvadosGetTestCase(run_test_server.TestCaseWithServers,
 
         # Confirm that progress is written to stderr when is a tty
         stderr.isatty.return_value = True
-        r = arv_get.main(['{}/bigfile.txt'.format(c.manifest_locator()),
+        r = self.run_get(['{}/bigfile.txt'.format(c.manifest_locator()),
                           '{}/bigfile.txt'.format(tmpdir)],
                          stdout, stderr)
         self.assertEqual(0, r)
@@ -190,7 +195,7 @@ class ArvadosGetTestCase(run_test_server.TestCaseWithServers,
 
         # Confirm that progress is not written to stderr when isn't a tty
         stderr.isatty.return_value = False
-        r = arv_get.main(['{}/bigfile.txt'.format(c.manifest_locator()),
+        r = self.run_get(['{}/bigfile.txt'.format(c.manifest_locator()),
                           '{}/bigfile.txt'.format(tmpdir)],
                          stdout, stderr)
         self.assertEqual(0, r)

--- a/sdk/python/tests/test_arv_keepdocker.py
+++ b/sdk/python/tests/test_arv_keepdocker.py
@@ -42,7 +42,7 @@ class ArvKeepdockerTestCase(unittest.TestCase, tutil.VersionChecker):
         with tutil.redirected_streams(stdout=out, stderr=out), \
              self.assertRaises(SystemExit) as cm:
             self.run_arv_keepdocker(['-x=unknown'], sys.stderr)
-        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(2, cm.exception.code)
         self.assertRegex(out.getvalue(), r'unrecognized arguments')
 
     def test_version_argument(self):

--- a/sdk/python/tests/test_arv_keepdocker.py
+++ b/sdk/python/tests/test_arv_keepdocker.py
@@ -40,8 +40,9 @@ class ArvKeepdockerTestCase(unittest.TestCase, tutil.VersionChecker):
     def test_unsupported_arg(self):
         out = tutil.StringIO()
         with tutil.redirected_streams(stdout=out, stderr=out), \
-             self.assertRaises(SystemExit):
+             self.assertRaises(SystemExit) as cm:
             self.run_arv_keepdocker(['-x=unknown'], sys.stderr)
+        self.assertEqual(cm.exception.code, 2)
         self.assertRegex(out.getvalue(), r'unrecognized arguments')
 
     def test_version_argument(self):
@@ -215,8 +216,8 @@ class ArvKeepdockerTestCase(unittest.TestCase, tutil.VersionChecker):
                             stdout=subprocess.PIPE)), \
              mock.patch('arvados.commands.keepdocker.prep_image_file',
                         return_value=(mocked_file, False)), \
-             mock.patch('arvados.commands.put.main',
-                        return_value='new-collection-uuid'), \
+             mock.patch('arvados.commands.put.do_put',
+                        return_value=(0, 'new-collection-uuid')), \
              self.assertRaises(StopTest):
 
             api()._rootDesc = fakeDD

--- a/sdk/python/tests/test_arv_ls.py
+++ b/sdk/python/tests/test_arv_ls.py
@@ -40,7 +40,9 @@ class ArvLsTestCase(run_test_server.TestCaseWithServers, tutil.VersionChecker):
     def run_ls(self, args, api_client, logger=None):
         self.stdout = StringIO()
         self.stderr = StringIO()
-        return arv_ls.main(args, self.stdout, self.stderr, api_client, logger)
+        with self.assertRaises(SystemExit) as cm:
+            arv_ls.main(args, self.stdout, self.stderr, api_client, logger)
+        return cm.exception.code
 
     def test_plain_listing(self):
         collection, api_client = self.mock_api_for_manifest(
@@ -90,6 +92,5 @@ class ArvLsTestCase(run_test_server.TestCaseWithServers, tutil.VersionChecker):
         import warnings
         warnings.simplefilter("ignore")
         with redirected_streams(stdout=StringIO, stderr=StringIO) as (out, err):
-            with self.assertRaises(SystemExit):
-                self.run_ls(['--version'], None)
+            self.assertEqual(0, self.run_ls(['--version'], None))
         self.assertVersionOutput(out, err)

--- a/sdk/python/tests/test_arv_put.py
+++ b/sdk/python/tests/test_arv_put.py
@@ -824,7 +824,9 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
     def call_do_put_on_test_file(self, args=[]):
         with self.make_test_file() as testfile:
             path = testfile.name
-            self.call_do_put_with_args(['--stream', '--no-progress'] + args + [path])
+            self.call_do_put_with_args(
+                ['--stream', '--no-progress'] + args + [path]
+            )
         self.assertTrue(
             os.path.exists(os.path.join(os.environ['KEEP_LOCAL_STORE'],
                                         '098f6bcd4621d373cade4e832627b4f6')),
@@ -899,8 +901,9 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
         test_paths = [testfile1.name, testfile2.name]
         # Reverse-sort the paths, so normalization must change their order.
         test_paths.sort(reverse=True)
-        self.call_do_put_with_args(['--stream', '--no-progress', '--normalize'] +
-                                 test_paths)
+        self.call_do_put_with_args(
+            ['--stream', '--no-progress', '--normalize'] + test_paths
+        )
         manifest = self.main_stdout.getvalue()
         # Assert the second file we specified appears first in the manifest.
         file_indices = [manifest.find(':' + os.path.basename(path))

--- a/sdk/python/tests/test_arv_put.py
+++ b/sdk/python/tests/test_arv_put.py
@@ -814,17 +814,17 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
     MAIN_SERVER = {}
     Z_UUID = 'zzzzz-zzzzz-zzzzzzzzzzzzzzz'
 
-    def call_main_with_args(self, args):
+    def call_do_put_with_args(self, args):
         self.main_stdout.seek(0, 0)
         self.main_stdout.truncate(0)
         self.main_stderr.seek(0, 0)
         self.main_stderr.truncate(0)
-        return arv_put.main(args, self.main_stdout, self.main_stderr)
+        return arv_put.do_put(args, self.main_stdout, self.main_stderr)
 
-    def call_main_on_test_file(self, args=[]):
+    def call_do_put_on_test_file(self, args=[]):
         with self.make_test_file() as testfile:
             path = testfile.name
-            self.call_main_with_args(['--stream', '--no-progress'] + args + [path])
+            self.call_do_put_with_args(['--stream', '--no-progress'] + args + [path])
         self.assertTrue(
             os.path.exists(os.path.join(os.environ['KEEP_LOCAL_STORE'],
                                         '098f6bcd4621d373cade4e832627b4f6')),
@@ -853,11 +853,11 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
         with tutil.redirected_streams(
                 stdout=tutil.StringIO, stderr=tutil.StringIO) as (out, err):
             with self.assertRaises(SystemExit):
-                self.call_main_with_args(['--version'])
+                self.call_do_put_with_args(['--version'])
         self.assertVersionOutput(out, err)
 
     def test_simple_file_put(self):
-        self.call_main_on_test_file()
+        self.call_do_put_on_test_file()
 
     def test_put_with_unwriteable_cache_dir(self):
         orig_cachedir = arv_put.ResumeCache.CACHE_DIR
@@ -865,7 +865,7 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
         os.chmod(cachedir, 0o0)
         arv_put.ResumeCache.CACHE_DIR = cachedir
         try:
-            self.call_main_on_test_file()
+            self.call_do_put_on_test_file()
         finally:
             arv_put.ResumeCache.CACHE_DIR = orig_cachedir
             os.chmod(cachedir, 0o700)
@@ -876,19 +876,19 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
         os.chmod(cachedir, 0o0)
         arv_put.ResumeCache.CACHE_DIR = os.path.join(cachedir, 'cachedir')
         try:
-            self.call_main_on_test_file()
+            self.call_do_put_on_test_file()
         finally:
             arv_put.ResumeCache.CACHE_DIR = orig_cachedir
             os.chmod(cachedir, 0o700)
 
     def test_put_block_replication(self):
-        self.call_main_on_test_file()
+        self.call_do_put_on_test_file()
         arv_put.api_client = None
         with mock.patch('arvados.collection.KeepClient.local_store_put') as put_mock:
             put_mock.return_value = 'acbd18db4cc2f85cedef654fccc4a4d8+3'
-            self.call_main_on_test_file(['--replication', '1'])
-            self.call_main_on_test_file(['--replication', '4'])
-            self.call_main_on_test_file(['--replication', '5'])
+            self.call_do_put_on_test_file(['--replication', '1'])
+            self.call_do_put_on_test_file(['--replication', '4'])
+            self.call_do_put_on_test_file(['--replication', '5'])
             self.assertEqual(
                 [x[-1].get('copies') for x in put_mock.call_args_list],
                 [1, 4, 5])
@@ -899,7 +899,7 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
         test_paths = [testfile1.name, testfile2.name]
         # Reverse-sort the paths, so normalization must change their order.
         test_paths.sort(reverse=True)
-        self.call_main_with_args(['--stream', '--no-progress', '--normalize'] +
+        self.call_do_put_with_args(['--stream', '--no-progress', '--normalize'] +
                                  test_paths)
         manifest = self.main_stdout.getvalue()
         # Assert the second file we specified appears first in the manifest.
@@ -908,26 +908,27 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
         self.assertGreater(*file_indices)
 
     def test_error_name_without_collection(self):
-        self.assertRaises(SystemExit, self.call_main_with_args,
-                          ['--name', 'test without Collection',
-                           '--stream', '/dev/null'])
+        status, _ = self.call_do_put_with_args(
+            ['--name', 'test without Collection', '--stream', '/dev/null']
+        )
+        self.assertEqual(2, status)
 
     def test_error_when_project_not_found(self):
-        self.assertRaises(SystemExit,
-                          self.call_main_with_args,
-                          ['--project-uuid', self.Z_UUID])
+        status, _ = self.call_do_put_with_args(['--project-uuid', self.Z_UUID])
+        self.assertEqual(1, status)
 
     def test_error_bad_project_uuid(self):
-        self.assertRaises(SystemExit,
-                          self.call_main_with_args,
-                          ['--project-uuid', self.Z_UUID, '--stream'])
+        status, _ = self.call_do_put_with_args(
+            ['--project-uuid', self.Z_UUID, '--stream']
+        )
+        self.assertEqual(2, status)
 
     def test_error_when_excluding_absolute_path(self):
         tmpdir = self.make_tmpdir()
-        self.assertRaises(SystemExit,
-                          self.call_main_with_args,
-                          ['--exclude', '/some/absolute/path/*',
-                           tmpdir])
+        status, _ = self.call_do_put_with_args(
+            ['--exclude', '/some/absolute/path/*', tmpdir]
+        )
+        self.assertEqual(2, status)
 
     def test_api_error_handling(self):
         coll_save_mock = mock.Mock(name='arv.collection.Collection().save_new()')
@@ -935,9 +936,8 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
             fake_httplib2_response(403), b'{}')
         with mock.patch('arvados.collection.Collection.save_new',
                         new=coll_save_mock):
-            with self.assertRaises(SystemExit) as exc_test:
-                self.call_main_with_args(['/dev/null'])
-            self.assertLess(0, exc_test.exception.args[0])
+            status, output = self.call_do_put_with_args(['/dev/null'])
+            self.assertLess(0, status)
             self.assertLess(0, coll_save_mock.call_count)
             self.assertEqual("", self.main_stdout.getvalue())
 
@@ -948,8 +948,7 @@ class ArvadosPutTest(run_test_server.TestCaseWithServers,
             fake_httplib2_response(403), b'{}')
         with mock.patch('arvados.collection.Collection.save_new',
                         new=coll_save_mock):
-            with self.assertRaises(SystemExit):
-                self.call_main_with_args(['/dev/null'])
+            self.call_do_put_with_args(['/dev/null'])
             self.assertRegex(
                 self.main_stderr.getvalue(), matcher)
 

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -114,17 +114,32 @@ class TestPassthroughCommands:
         "subcommand,cmd_mod_name",
         arvcli.ArvCLIArgumentParser.external_command_modules.items()
     )
-    def test_args(self, subcommand, cmd_mod_name, run_arvcli):
+    def test_pass_through(self, subcommand, cmd_mod_name, run_arvcli):
         """Test that arbitrary argv ('[...] arvcli.py subcommand --foo bar') to
         arvcli.py gets passed to the underlying subcommand; i.e. the
         passed-through subcommand's `main()` function gets called with
-        ["--foo", "bar"].
+        ["--foo", "bar"].  `arvcli` then exits when the imported `main()` does,
+        with whatever exit code the `main()` generates.
         """
         mock_mod = mock.Mock()
+
+        def mock_main(*args, **kwargs):
+            """Alters some external state, then exits."""
+            print("fake out")
+            print("fake err", file=sys.stderr)
+            sys.exit(42)
+
+        mock_mod.main.side_effect = mock_main
         with pytest.MonkeyPatch.context() as m:
             m.setitem(sys.modules, cmd_mod_name, mock_mod)
-            run_arvcli([*subcommand.split(), "--foo", "bar"])
+            exit_code, out, err = run_arvcli(
+                [*subcommand.split(), "--foo", "bar"]
+            )
+
         mock_mod.main.assert_called_with(["--foo", "bar"])
+        assert exit_code == 42
+        assert out.rstrip() == "fake out"
+        assert err.rstrip() == "fake err"
 
     @pytest.mark.parametrize(
         "subcommand", arvcli.ArvCLIArgumentParser.external_command_modules


### PR DESCRIPTION
`432-python-commands-exit-consistently` @ 3b681097cedd466a0a312e9797dd2da44ac1a990

https://ci.arvados.org/job/developer-run-tests/5104/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * _Yes_; before the implementation, the `main()` functions behave differently:
    * `arv_copy.py` and `keepdocker.py` call `sys.exit()`, although the former did it a bit incorrectly (calling the top-level `exit()` created by the `site` module for interactive interpreter, rather than `sys.exit()`)
    * `get.py` and `ls.py` return an integer status.
    * `put.py` did sort of both: calling `sys.exit()` on error but returns a string value upon success.
  * After the implementation, all of those `main()` functions are NoReturn (calling `sys.exit()`)
    * For `put.py`, the function that does the majority of work is needed by `keepdocker.py`. This function is now named `do_put()`, which returns a tuple `(integer_code, str_output)`. `do_put()` may still call `sys.exit()` if given nonsensical arguments (because it calls `argparse.ArgumentParser.parse_args()`).
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * See #433 (not related)
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Tests routines are revised to adapt to the new convention implemented in this change. Manually tested with running `arv {copy|keep ls|keep get|keep put}` commands via arvcli.py.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_ (largely internal changes without outside observable behavior change)
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _Yes_ (not affected)
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_ for new Python code.

Additionally, in `put.py`, it used to be the case that most errors cause exit with status 1. I've made it exit with 2 when the error is caused by incorrect command-line input, and reserved 1 for run-time errors.

Closes #432.