### PR TITLE
440: Controller sends HTTP 400 upon invalid manifest for replace_files.

### DIFF
--- a/lib/controller/localdb/collection.go
+++ b/lib/controller/localdb/collection.go
@@ -290,7 +290,7 @@ func (conn *Conn) applyReplaceFilesOption(ctx context.Context, fromUUID string, 
 			srccoll := &arvados.Collection{ManifestText: providedManifestText}
 			srcfs, err = srccoll.FileSystem(&arvados.StubClient{}, &arvados.StubClient{})
 			if err != nil {
-				if errors.Is(err, arvados.ErrInvalidManifestText) {
+				if errors.Is(err, arvados.ErrMalformedManifestText) {
 					return nil, httpserver.Errorf(http.StatusBadRequest, "replace_files: %w", err)
 				}
 				return nil, err

--- a/lib/controller/localdb/collection.go
+++ b/lib/controller/localdb/collection.go
@@ -289,10 +289,9 @@ func (conn *Conn) applyReplaceFilesOption(ctx context.Context, fromUUID string, 
 			srcfs = nil
 			srccoll := &arvados.Collection{ManifestText: providedManifestText}
 			srcfs, err = srccoll.FileSystem(&arvados.StubClient{}, &arvados.StubClient{})
-			if err != nil {
-				if errors.Is(err, arvados.ErrMalformedManifestText) {
-					return nil, httpserver.Errorf(http.StatusBadRequest, "replace_files: %w", err)
-				}
+			if errors.Is(err, arvados.ErrMalformedManifestText) {
+				return nil, httpserver.Errorf(http.StatusBadRequest, "replace_files: %w", err)
+			} else if err != nil {
 				return nil, err
 			}
 			srcidloaded = srcid

--- a/lib/controller/localdb/collection.go
+++ b/lib/controller/localdb/collection.go
@@ -6,6 +6,7 @@ package localdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -289,6 +290,9 @@ func (conn *Conn) applyReplaceFilesOption(ctx context.Context, fromUUID string, 
 			srccoll := &arvados.Collection{ManifestText: providedManifestText}
 			srcfs, err = srccoll.FileSystem(&arvados.StubClient{}, &arvados.StubClient{})
 			if err != nil {
+				if errors.Is(err, arvados.ErrInvalidManifestText) {
+					return nil, httpserver.Errorf(http.StatusBadRequest, "replace_files: %w", err)
+				}
 				return nil, err
 			}
 			srcidloaded = srcid

--- a/lib/controller/localdb/collection_test.go
+++ b/lib/controller/localdb/collection_test.go
@@ -456,12 +456,12 @@ func (s *replaceFilesSuite) TestUnusedManifestText_Update(c *check.C) {
 	c.Check(err, check.ErrorMatches, `.*manifest_text.*would not be used.*`)
 }
 
-func (s *replaceFilesSuite) TestInvalidManifestText_Create(c *check.C) {
+func (s *replaceFilesSuite) TestMalformedManifestText_Create(c *check.C) {
 	// NOTE: No newline at the end.
-	invalidManifestText := ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo"
+	malformedManifestText := ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo"
 	_, err := s.localdb.CollectionCreate(s.userctx, arvados.CreateOptions{
 		Attrs: map[string]interface{}{
-			"manifest_text": invalidManifestText,
+			"manifest_text": malformedManifestText,
 		},
 		ReplaceFiles: map[string]string{
 			"/bar.txt": "manifest_text/foo",
@@ -469,15 +469,15 @@ func (s *replaceFilesSuite) TestInvalidManifestText_Create(c *check.C) {
 	var se httpserver.HTTPStatusError
 	c.Check(errors.As(err, &se), check.Equals, true)
 	c.Check(se.HTTPStatus(), check.Equals, http.StatusBadRequest)
-	c.Check(err, check.ErrorMatches, `.* invalid manifest_text: .*`)
+	c.Check(err, check.ErrorMatches, `.* malformed manifest_text: .*`)
 }
 
-func (s *replaceFilesSuite) TestInvalidManifestText_Update(c *check.C) {
-	invalidManifestText := ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo"
+func (s *replaceFilesSuite) TestMalformedManifestText_Update(c *check.C) {
+	malformedManifestText := ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo"
 	_, err := s.localdb.CollectionUpdate(s.userctx, arvados.UpdateOptions{
 		UUID: s.tmp.UUID,
 		Attrs: map[string]interface{}{
-			"manifest_text": invalidManifestText,
+			"manifest_text": malformedManifestText,
 		},
 		ReplaceFiles: map[string]string{
 			"/bar.txt": "manifest_text/foo",
@@ -485,7 +485,7 @@ func (s *replaceFilesSuite) TestInvalidManifestText_Update(c *check.C) {
 	var se httpserver.HTTPStatusError
 	c.Check(errors.As(err, &se), check.Equals, true)
 	c.Check(se.HTTPStatus(), check.Equals, http.StatusBadRequest)
-	c.Check(err, check.ErrorMatches, `.* invalid manifest_text: .*`)
+	c.Check(err, check.ErrorMatches, `.* malformed manifest_text: .*`)
 }
 
 func (s *replaceFilesSuite) TestConcurrentRename(c *check.C) {

--- a/lib/controller/localdb/collection_test.go
+++ b/lib/controller/localdb/collection_test.go
@@ -456,6 +456,38 @@ func (s *replaceFilesSuite) TestUnusedManifestText_Update(c *check.C) {
 	c.Check(err, check.ErrorMatches, `.*manifest_text.*would not be used.*`)
 }
 
+func (s *replaceFilesSuite) TestInvalidManifestText_Create(c *check.C) {
+	// NOTE: No newline at the end.
+	invalidManifestText := ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo"
+	_, err := s.localdb.CollectionCreate(s.userctx, arvados.CreateOptions{
+		Attrs: map[string]interface{}{
+			"manifest_text": invalidManifestText,
+		},
+		ReplaceFiles: map[string]string{
+			"/bar.txt": "manifest_text/foo",
+		}})
+	var se httpserver.HTTPStatusError
+	c.Check(errors.As(err, &se), check.Equals, true)
+	c.Check(se.HTTPStatus(), check.Equals, http.StatusBadRequest)
+	c.Check(err, check.ErrorMatches, `.* invalid manifest_text: .*`)
+}
+
+func (s *replaceFilesSuite) TestInvalidManifestText_Update(c *check.C) {
+	invalidManifestText := ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo"
+	_, err := s.localdb.CollectionUpdate(s.userctx, arvados.UpdateOptions{
+		UUID: s.tmp.UUID,
+		Attrs: map[string]interface{}{
+			"manifest_text": invalidManifestText,
+		},
+		ReplaceFiles: map[string]string{
+			"/bar.txt": "manifest_text/foo",
+		}})
+	var se httpserver.HTTPStatusError
+	c.Check(errors.As(err, &se), check.Equals, true)
+	c.Check(se.HTTPStatus(), check.Equals, http.StatusBadRequest)
+	c.Check(err, check.ErrorMatches, `.* invalid manifest_text: .*`)
+}
+
 func (s *replaceFilesSuite) TestConcurrentRename(c *check.C) {
 	var wg sync.WaitGroup
 	var renamed atomic.Int32

--- a/sdk/go/arvados/fs_collection.go
+++ b/sdk/go/arvados/fs_collection.go
@@ -1777,16 +1777,16 @@ func splitToToks(src []byte, c rune, toks [][]byte) int {
 	return 3
 }
 
-var ErrInvalidManifestText = errors.New("invalid manifest_text")
+var ErrMalformedManifestText = errors.New("malformed manifest_text")
 
-func invmtErrorf(format string, args ...interface{}) error {
-	return fmt.Errorf("%w: %s", ErrInvalidManifestText, fmt.Sprintf(format, args...))
+func badmtxtErrorf(format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s", ErrMalformedManifestText, fmt.Sprintf(format, args...))
 }
 
 func (dn *dirnode) loadManifest(txt string) error {
 	streams := bytes.Split([]byte(txt), []byte{'\n'})
 	if len(streams[len(streams)-1]) != 0 {
-		return invmtErrorf("line %d: no trailing newline", len(streams))
+		return badmtxtErrorf("line %d: no trailing newline", len(streams))
 	}
 	streams = streams[:len(streams)-1]
 	segments := []storedSegment{}
@@ -1818,14 +1818,14 @@ func (dn *dirnode) loadManifest(txt string) error {
 			}
 			if !bytes.ContainsRune(token, ':') {
 				if anyFileTokens {
-					return invmtErrorf("line %d: bad file segment %q", lineno, token)
+					return badmtxtErrorf("line %d: bad file segment %q", lineno, token)
 				}
 				if splitToToks(token, '+', toks) < 2 {
-					return invmtErrorf("line %d: bad locator %q", lineno, token)
+					return badmtxtErrorf("line %d: bad locator %q", lineno, token)
 				}
 				length, err := strconv.ParseInt(string(toks[1]), 10, 32)
 				if err != nil || length < 0 {
-					return invmtErrorf("line %d: bad locator %q", lineno, token)
+					return badmtxtErrorf("line %d: bad locator %q", lineno, token)
 				}
 				streamoffset = append(streamoffset, streamoffset[len(segments)]+int64(length))
 				segments = append(segments, storedSegment{
@@ -1836,20 +1836,20 @@ func (dn *dirnode) loadManifest(txt string) error {
 				})
 				continue
 			} else if len(segments) == 0 {
-				return invmtErrorf("line %d: bad locator %q", lineno, token)
+				return badmtxtErrorf("line %d: bad locator %q", lineno, token)
 			}
 			if splitToToks(token, ':', toks) != 3 {
-				return invmtErrorf("line %d: bad file segment %q", lineno, token)
+				return badmtxtErrorf("line %d: bad file segment %q", lineno, token)
 			}
 			anyFileTokens = true
 
 			offset, err := strconv.ParseInt(string(toks[0]), 10, 64)
 			if err != nil || offset < 0 {
-				return invmtErrorf("line %d: bad file segment %q", lineno, token)
+				return badmtxtErrorf("line %d: bad file segment %q", lineno, token)
 			}
 			length, err := strconv.ParseInt(string(toks[1]), 10, 64)
 			if err != nil || length < 0 {
-				return invmtErrorf("line %d: bad file segment %q", lineno, token)
+				return badmtxtErrorf("line %d: bad file segment %q", lineno, token)
 			}
 			fnode, cached := fnodeCache[string(toks[2])]
 			if !cached {
@@ -1861,14 +1861,14 @@ func (dn *dirnode) loadManifest(txt string) error {
 				}
 				fnode, err = dn.createFileAndParents(pathparts)
 				if err != nil {
-					return invmtErrorf("line %d: cannot use name %q with length %d: %s", lineno, toks[2], length, err)
+					return badmtxtErrorf("line %d: cannot use name %q with length %d: %s", lineno, toks[2], length, err)
 				}
 				fnodeCache[string(toks[2])] = fnode
 			}
 			if fnode == nil {
 				// name matches an existing directory
 				if length != 0 {
-					return invmtErrorf("line %d: cannot use name %q with length %d: is a directory", lineno, toks[2], length)
+					return badmtxtErrorf("line %d: cannot use name %q with length %d: is a directory", lineno, toks[2], length)
 				}
 				// Special case: an empty file used as
 				// a marker to preserve an otherwise
@@ -1919,15 +1919,15 @@ func (dn *dirnode) loadManifest(txt string) error {
 				})
 			}
 			if segIdx == len(segments) && streamoffset[segIdx] < offset+length {
-				return invmtErrorf("line %d: invalid segment in %d-byte stream: %q", lineno, streamoffset[segIdx], token)
+				return badmtxtErrorf("line %d: invalid segment in %d-byte stream: %q", lineno, streamoffset[segIdx], token)
 			}
 		}
 		if !anyFileTokens {
-			return invmtErrorf("line %d: no file segments", lineno)
+			return badmtxtErrorf("line %d: no file segments", lineno)
 		} else if len(segments) == 0 {
-			return invmtErrorf("line %d: no locators", lineno)
+			return badmtxtErrorf("line %d: no locators", lineno)
 		} else if streamparts == 0 {
-			return invmtErrorf("line %d: no stream name", lineno)
+			return badmtxtErrorf("line %d: no stream name", lineno)
 		}
 	}
 	return nil

--- a/sdk/go/arvados/fs_collection.go
+++ b/sdk/go/arvados/fs_collection.go
@@ -1780,7 +1780,8 @@ func splitToToks(src []byte, c rune, toks [][]byte) int {
 var ErrMalformedManifestText = errors.New("malformed manifest_text")
 
 func badmtxtErrorf(format string, args ...interface{}) error {
-	return fmt.Errorf("%w: %s", ErrMalformedManifestText, fmt.Sprintf(format, args...))
+	allArgs := append([]interface{}{ErrMalformedManifestText}, args...)
+	return fmt.Errorf("%w: "+format, allArgs...)
 }
 
 func (dn *dirnode) loadManifest(txt string) error {

--- a/sdk/go/arvados/fs_collection.go
+++ b/sdk/go/arvados/fs_collection.go
@@ -1780,7 +1780,7 @@ func splitToToks(src []byte, c rune, toks [][]byte) int {
 var ErrMalformedManifestText = errors.New("malformed manifest_text")
 
 func badmtxtErrorf(format string, args ...interface{}) error {
-	allArgs := append([]interface{}{ErrMalformedManifestText}, args...)
+	allArgs := slices.Concat([]interface{}{ErrMalformedManifestText}, args)
 	return fmt.Errorf("%w: "+format, allArgs...)
 }
 

--- a/sdk/go/arvados/fs_collection.go
+++ b/sdk/go/arvados/fs_collection.go
@@ -1777,10 +1777,16 @@ func splitToToks(src []byte, c rune, toks [][]byte) int {
 	return 3
 }
 
+var ErrInvalidManifestText = errors.New("invalid manifest_text")
+
+func invmtErrorf(format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s", ErrInvalidManifestText, fmt.Sprintf(format, args...))
+}
+
 func (dn *dirnode) loadManifest(txt string) error {
 	streams := bytes.Split([]byte(txt), []byte{'\n'})
 	if len(streams[len(streams)-1]) != 0 {
-		return fmt.Errorf("line %d: no trailing newline", len(streams))
+		return invmtErrorf("line %d: no trailing newline", len(streams))
 	}
 	streams = streams[:len(streams)-1]
 	segments := []storedSegment{}
@@ -1812,14 +1818,14 @@ func (dn *dirnode) loadManifest(txt string) error {
 			}
 			if !bytes.ContainsRune(token, ':') {
 				if anyFileTokens {
-					return fmt.Errorf("line %d: bad file segment %q", lineno, token)
+					return invmtErrorf("line %d: bad file segment %q", lineno, token)
 				}
 				if splitToToks(token, '+', toks) < 2 {
-					return fmt.Errorf("line %d: bad locator %q", lineno, token)
+					return invmtErrorf("line %d: bad locator %q", lineno, token)
 				}
 				length, err := strconv.ParseInt(string(toks[1]), 10, 32)
 				if err != nil || length < 0 {
-					return fmt.Errorf("line %d: bad locator %q", lineno, token)
+					return invmtErrorf("line %d: bad locator %q", lineno, token)
 				}
 				streamoffset = append(streamoffset, streamoffset[len(segments)]+int64(length))
 				segments = append(segments, storedSegment{
@@ -1830,20 +1836,20 @@ func (dn *dirnode) loadManifest(txt string) error {
 				})
 				continue
 			} else if len(segments) == 0 {
-				return fmt.Errorf("line %d: bad locator %q", lineno, token)
+				return invmtErrorf("line %d: bad locator %q", lineno, token)
 			}
 			if splitToToks(token, ':', toks) != 3 {
-				return fmt.Errorf("line %d: bad file segment %q", lineno, token)
+				return invmtErrorf("line %d: bad file segment %q", lineno, token)
 			}
 			anyFileTokens = true
 
 			offset, err := strconv.ParseInt(string(toks[0]), 10, 64)
 			if err != nil || offset < 0 {
-				return fmt.Errorf("line %d: bad file segment %q", lineno, token)
+				return invmtErrorf("line %d: bad file segment %q", lineno, token)
 			}
 			length, err := strconv.ParseInt(string(toks[1]), 10, 64)
 			if err != nil || length < 0 {
-				return fmt.Errorf("line %d: bad file segment %q", lineno, token)
+				return invmtErrorf("line %d: bad file segment %q", lineno, token)
 			}
 			fnode, cached := fnodeCache[string(toks[2])]
 			if !cached {
@@ -1855,14 +1861,14 @@ func (dn *dirnode) loadManifest(txt string) error {
 				}
 				fnode, err = dn.createFileAndParents(pathparts)
 				if err != nil {
-					return fmt.Errorf("line %d: cannot use name %q with length %d: %s", lineno, toks[2], length, err)
+					return invmtErrorf("line %d: cannot use name %q with length %d: %s", lineno, toks[2], length, err)
 				}
 				fnodeCache[string(toks[2])] = fnode
 			}
 			if fnode == nil {
 				// name matches an existing directory
 				if length != 0 {
-					return fmt.Errorf("line %d: cannot use name %q with length %d: is a directory", lineno, toks[2], length)
+					return invmtErrorf("line %d: cannot use name %q with length %d: is a directory", lineno, toks[2], length)
 				}
 				// Special case: an empty file used as
 				// a marker to preserve an otherwise
@@ -1913,15 +1919,15 @@ func (dn *dirnode) loadManifest(txt string) error {
 				})
 			}
 			if segIdx == len(segments) && streamoffset[segIdx] < offset+length {
-				return fmt.Errorf("line %d: invalid segment in %d-byte stream: %q", lineno, streamoffset[segIdx], token)
+				return invmtErrorf("line %d: invalid segment in %d-byte stream: %q", lineno, streamoffset[segIdx], token)
 			}
 		}
 		if !anyFileTokens {
-			return fmt.Errorf("line %d: no file segments", lineno)
+			return invmtErrorf("line %d: no file segments", lineno)
 		} else if len(segments) == 0 {
-			return fmt.Errorf("line %d: no locators", lineno)
+			return invmtErrorf("line %d: no locators", lineno)
 		} else if streamparts == 0 {
-			return fmt.Errorf("line %d: no stream name", lineno)
+			return invmtErrorf("line %d: no stream name", lineno)
 		}
 	}
 	return nil

--- a/sdk/go/arvados/fs_collection_test.go
+++ b/sdk/go/arvados/fs_collection_test.go
@@ -213,17 +213,17 @@ func (s *CollectionFSSuite) TestUnattainableStorageClasses(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `.*stub does not write storage class \"unobtainium\"`)
 }
 
-func (s *CollectionFSSuite) TestInvalidManifests(c *check.C) {
-	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo", `^invalid manifest_text: line 1: no trailing newline$`)
-	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e 0:0:foo\n", `^invalid manifest_text: line 1: bad locator "d41d8cd98f00b204e9800998ecf8427e"$`)
-	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+x 0:0:foo\n", `^invalid manifest_text: line 1: bad locator "d41d8cd98f00b204e9800998ecf8427e\+x"$`)
-	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+0 ::foo\n", `^invalid manifest_text: line 1: bad file segment "::foo"$`)
+func (s *CollectionFSSuite) TestMalformedManifests(c *check.C) {
+	s.testMalformedManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo", `^malformed manifest_text: line 1: no trailing newline$`)
+	s.testMalformedManifest(c, ". d41d8cd98f00b204e9800998ecf8427e 0:0:foo\n", `^malformed manifest_text: line 1: bad locator "d41d8cd98f00b204e9800998ecf8427e"$`)
+	s.testMalformedManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+x 0:0:foo\n", `^malformed manifest_text: line 1: bad locator "d41d8cd98f00b204e9800998ecf8427e\+x"$`)
+	s.testMalformedManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+0 ::foo\n", `^malformed manifest_text: line 1: bad file segment "::foo"$`)
 }
 
-func (s *CollectionFSSuite) testInvalidManifest(c *check.C, manifest string, expectReason string) {
+func (s *CollectionFSSuite) testMalformedManifest(c *check.C, manifest string, expectReason string) {
 	coll := Collection{ManifestText: manifest}
 	_, err := coll.FileSystem(s.client, s.kc)
-	c.Check(errors.Is(err, ErrInvalidManifestText), check.Equals, true)
+	c.Check(errors.Is(err, ErrMalformedManifestText), check.Equals, true)
 	c.Assert(err, check.ErrorMatches, expectReason)
 }
 

--- a/sdk/go/arvados/fs_collection_test.go
+++ b/sdk/go/arvados/fs_collection_test.go
@@ -213,6 +213,20 @@ func (s *CollectionFSSuite) TestUnattainableStorageClasses(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `.*stub does not write storage class \"unobtainium\"`)
 }
 
+func (s *CollectionFSSuite) TestInvalidManifests(c *check.C) {
+	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+0 0:0:foo", `^invalid manifest_text: line 1: no trailing newline$`)
+	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e 0:0:foo\n", `^invalid manifest_text: line 1: bad locator "d41d8cd98f00b204e9800998ecf8427e"$`)
+	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+x 0:0:foo\n", `^invalid manifest_text: line 1: bad locator "d41d8cd98f00b204e9800998ecf8427e\+x"$`)
+	s.testInvalidManifest(c, ". d41d8cd98f00b204e9800998ecf8427e+0 ::foo\n", `^invalid manifest_text: line 1: bad file segment "::foo"$`)
+}
+
+func (s *CollectionFSSuite) testInvalidManifest(c *check.C, manifest string, expectReason string) {
+	coll := Collection{ManifestText: manifest}
+	_, err := coll.FileSystem(s.client, s.kc)
+	c.Check(errors.Is(err, ErrInvalidManifestText), check.Equals, true)
+	c.Assert(err, check.ErrorMatches, expectReason)
+}
+
 func (s *CollectionFSSuite) TestColonInFilename(c *check.C) {
 	fs, err := (&Collection{
 		ManifestText: "./foo:foo 3858f62230ac3c915f300c664312c63f+3 0:3:bar:bar\n",


### PR DESCRIPTION
`440-return-http-400-bad-request-on-invalid-manifest-for-replace_files` @ cdd2a326b0612ca0bc7c86edc8f74a01d27c8642

https://ci.arvados.org/job/developer-run-tests/5109/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * I tried to implement minimally invasive changes to the SDK code: whereas formerly the private method `loadManifest()` returns a plain error created by `fmt.Errorf()`, here it returns one, also created by `fmt.Errorf()`, that wraps the custom sentinel error `ErrInvalidManifestText`. On the controller side, upon calling `Collection.FileSystem()` and checking the error with `errors.Is()`, send the error response with `httpserver.Errorf(http.StatusBadRequest, ...)`.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * I added some test cases on both sides and they pass.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * The update should minimally affect the most common case (the provided `manifest_text` being actually valid). Upon invalid `manifest_text`, by informing a semantics-compliant client with the 400 code, we may actually prevent inadvertent (and futile) retries.
* Considered backwards and forwards compatibility issues between client and server.
  * This should improve the interoperability with the `googleapiclient`-based Python client marginally (that is, upon the specific kind of invalid input).
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * Yes (gofmt).

Closes #440.