### PR TITLE
444: Update documentation for `arvados.collection.Collection.find()`.

### DIFF
--- a/sdk/python/arvados/collection.py
+++ b/sdk/python/arvados/collection.py
@@ -69,7 +69,7 @@ ChangeList = List[Union[
     Tuple[Literal[MOD, TOK], str, 'Collection', 'Collection'],
 ]]
 ChangeType = Literal[ADD, DEL, MOD, TOK]
-CollectionItem = Union[ArvadosFile, 'Collection']
+CollectionItem = Union[ArvadosFile, 'Collection', 'Subcollection']
 ChangeCallback = Callable[[ChangeType, 'Collection', str, CollectionItem], object]
 CreateType = Literal[COLLECTION, FILE]
 Properties = Dict[str, Any]
@@ -276,18 +276,29 @@ class RichCollectionBase(CollectionBase):
             return self
 
     @synchronized
-    def find(self, path: str) -> CollectionItem:
-        """Get the item at the given path
+    def find(self, path: str) -> CollectionItem | None:
+        """Get the item at the given path.
 
         If `path` refers to a stream in this collection, returns a
-        corresponding `Subcollection` object. If `path` refers to a file in
-        this collection, returns a corresponding
-        `arvados.arvfile.ArvadosFile` object. If `path` does not exist in
-        this collection, then this method raises `NotADirectoryError`.
+        corresponding `Subcollection` object.
+
+        As a special case, if `path` is `"."`, returns the collection itself.
+
+        If `path` refers to a file in this collection, returns a corresponding
+        `arvados.arvfile.ArvadosFile` object.
+
+        If `path` does not exist in this collection, then this method returns
+        `None`.
+
+        A `path` that begins with the slash (`/`) character is invalid;
+        `NotADirectoryError` is raised in this case.
+
+        An empty `path` is invalid, and `arvados.errors.ArgumentError` is
+        raised.
 
         Arguments:
 
-        * path: str --- The path to find or create within this collection.
+        * path: str --- The path to find within this collection.
         """
         if not path:
             raise errors.ArgumentError("Parameter 'path' is empty.")
@@ -308,7 +319,9 @@ class RichCollectionBase(CollectionBase):
                 else:
                     return item
             else:
-                raise IOError(errno.ENOTDIR, "Not a directory", pathcomponents[0])
+                raise IOError(
+                    errno.ENOTDIR, "Not a directory", pathcomponents[0]
+                )
 
     @synchronized
     def mkdirs(self, path: str) -> 'Subcollection':
@@ -1453,7 +1466,7 @@ class Collection(RichCollectionBase):
         else:
             return super(Collection, self).find_or_create(path[2:] if path.startswith("./") else path, create_type)
 
-    def find(self, path: str) -> CollectionItem:
+    def find(self, path: str) -> CollectionItem | None:
         if path == ".":
             return self
         else:

--- a/sdk/python/tests/test_collections.py
+++ b/sdk/python/tests/test_collections.py
@@ -5,6 +5,7 @@
 import ciso8601
 import copy
 import datetime
+import errno
 import os
 import random
 import re
@@ -614,8 +615,9 @@ class NewCollectionTestCase(unittest.TestCase, CollectionTestMixin):
         self.assertIs(c.find("."), c)
         self.assertIs(c.find("./count1.txt"), c["count1.txt"])
         self.assertIs(c.find("count1.txt"), c["count1.txt"])
-        with self.assertRaises(IOError):
+        with self.assertRaises(IOError) as exc_cm:
             c.find("/.")
+        self.assertEqual(exc_cm.exception.errno, errno.ENOTDIR)
         with self.assertRaises(arvados.errors.ArgumentError):
             c.find("")
         self.assertIs(c.find("./nonexistant.txt"), None)


### PR DESCRIPTION
`444-fix-collection-find-documentation` @ e8a31b1763cb0f9ebc1ceabe1cbe67415233d874

Jenkins build TBD (currently appears to be stuck)

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Documentation: Fixed description of return value and the corresponding type annotation; the code is not touched except for pep-8 formatting.
  * Tests: Updated test to check exception details (errno) when the invalid input looks like an absolute path.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Tested and passing locally: `sdk/python`, `sdk/cwl`, `services/fuse`
  * Ran local `test doc` to inspect the generated Python pdoc documentation.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _Yes_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * This update in itself maintains the status quo.
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * Yes

Many thanks to @ja-ro488 for the bug report.

Closes #444.