### PR TITLE
446: DRY-up derived classes for JSON/YAML editing processes in arvcli.

### DIFF
--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -358,7 +358,7 @@ class ObjectEditingProcessBase(AbstractContextManager, abc.ABC):
     * base_command: list[str] --- Command-line argument list for invoking the
       external editor program. See `get_editor_cmdline()` for more.
     """
-    _tmpfile_extension = None
+    _file_type = None
 
     def __init__(self, initial_object=None, prefix=None, file_extension=None):
         """Arguments:
@@ -390,8 +390,8 @@ class ObjectEditingProcessBase(AbstractContextManager, abc.ABC):
         else:
             self.prefix = None
 
-        ext = self._tmpfile_extension or file_extension
-        self.suffix = f".{ext}" if ext else None
+        ext = self._file_type or file_extension
+        self.suffix = f".{ext.lower()}" if ext else None
 
         self.tmp_file = None
         self.base_command = self.get_editor_cmdline()
@@ -500,12 +500,36 @@ class EditingContentError(ValueError):
         return msg
 
 
-class JSONEditingProcess(ObjectEditingProcessBase):
+class LoadingHelper:
+    """Helper class to provide shared error handling and validation traits for
+    the temp file being edited (whose content shall be an Arvados object).
+    """
+    def raise_bad_format(
+        self, file: TextIO, err: Exception, line: int = 0, column: int = 0
+    ) -> NoReturn:
+        path = getattr(file, "name", "<unknown path>")
+        raise EditingContentError(
+            path=path, line=line, column=column, file_type=self._file_type,
+            original_exception=err
+        )
+
+    def validate_mapping(self, obj: Any, file: TextIO) -> Mapping[str, Any]:
+        if not isinstance(obj, Mapping):
+            path = getattr(file, "name", "<unknown path>")
+            format_name = self._file_type or "<unknown format>"
+            raise EditingContentError(
+                path=path,
+                original_exception=ValueError(
+                    f"{format_name} input has type '{type(obj).__name__}',"
+                    " not a valid Arvados object"
+                )
+            )
+        return obj
+
+
+class JSONEditingProcess(LoadingHelper, ObjectEditingProcessBase):
     """Subclass of editing process tuned for JSON files."""
-    _tmpfile_extension = "json"
-    input_error_type = functools.partial(
-        EditingContentError, file_type="JSON"
-    )
+    _file_type = "JSON"
 
     def __init__(self, *args, indent: int = 1, **kwargs):
         """Arguments:
@@ -520,61 +544,30 @@ class JSONEditingProcess(ObjectEditingProcessBase):
         return json.dump(obj, file, indent=self.indent)
 
     def deserialize(self, file: TextIO) -> Mapping[str, Any]:
-        path = getattr(file, "name", "<unknown path>")
         try:
             obj = json.load(file)
         except json.JSONDecodeError as err:
-            line = getattr(err, "lineno", 0)
-            column = getattr(err, "colno", 0)
-            raise self.input_error_type(
-                path=path, line=line, column=column,
-                original_exception=err
-            )
-        if not isinstance(obj, Mapping):
-            raise self.input_error_type(
-                path=path,
-                original_exception=ValueError(
-                    f"JSON input has type '{type(obj).__name__}',"
-                    " not a valid Arvados object"
-                )
-            )
-        return obj
+            self.raise_bad_format(file, err, err.lineno, err.colno)
+        return self.validate_mapping(obj, file)
 
 
-class YAMLEditingProcess(ObjectEditingProcessBase):
+class YAMLEditingProcess(LoadingHelper, ObjectEditingProcessBase):
     """Subclass of editing process tuned for YAML files."""
-    _tmpfile_extension = "yml"
-    input_error_type = functools.partial(
-        EditingContentError, file_type="YAML"
-    )
+    _file_type = "YAML"
 
     def serialize(self, obj: Mapping[str, Any], file: TextIO) -> None:
         return yaml.dump(obj, file)
 
     def deserialize(self, file: TextIO) -> Mapping[str, Any]:
-        path = getattr(file, "name", "<unknown path>")
         try:
             obj = yaml.load(file)
         except YAMLError as err:
-            if problem_mark := getattr(err, "problem_mark", None):
-                line = getattr(problem_mark, "line", 0)
-                column = getattr(problem_mark, "column", 0)
-            else:
-                line = 0
-                column = 0
-            raise self.input_error_type(
-                path=path, line=line, column=column,
-                original_exception=err
-            )
-        if not isinstance(obj, Mapping):
-            raise self.input_error_type(
-                path=path,
-                original_exception=ValueError(
-                    f"YAML input has type '{type(obj).__name__}',"
-                    " not a valid Arvados object"
-                )
-            )
-        return obj
+            # We only do "getattr" because YAMLError is sparsely documented.
+            problem_mark = getattr(err, "problem_mark", None)
+            line = getattr(problem_mark, "line", 0)
+            column = getattr(problem_mark, "column", 0)
+            self.raise_bad_format(file, err, line, column)
+        return self.validate_mapping(obj, file)
 
 
 class FullHelpOnErrorArgumentParser(argparse.ArgumentParser):

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -516,12 +516,11 @@ class ArvObjLoadingHelper:
     def validate_mapping(self, obj: Any, file: TextIO) -> Mapping[str, Any]:
         if not isinstance(obj, Mapping):
             path = getattr(file, "name", "<unknown path>")
-            format_name = self._file_type or "<unknown format>"
             raise EditingContentError(
-                path=path,
+                path=path, file_type=self._file_type,
                 original_exception=ValueError(
-                    f"{format_name} input has type '{type(obj).__name__}',"
-                    " not a valid Arvados object"
+                    f"{self._file_type or 'unknown-format'} input has type"
+                    f" '{type(obj).__name__}', not a valid Arvados object"
                 )
             )
         return obj

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -500,7 +500,7 @@ class EditingContentError(ValueError):
         return msg
 
 
-class LoadingHelper:
+class ArvObjLoadingHelper:
     """Helper class to provide shared error handling and validation traits for
     the temp file being edited (whose content shall be an Arvados object).
     """
@@ -527,7 +527,7 @@ class LoadingHelper:
         return obj
 
 
-class JSONEditingProcess(LoadingHelper, ObjectEditingProcessBase):
+class JSONEditingProcess(ArvObjLoadingHelper, ObjectEditingProcessBase):
     """Subclass of editing process tuned for JSON files."""
     _file_type = "JSON"
 
@@ -551,7 +551,7 @@ class JSONEditingProcess(LoadingHelper, ObjectEditingProcessBase):
         return self.validate_mapping(obj, file)
 
 
-class YAMLEditingProcess(LoadingHelper, ObjectEditingProcessBase):
+class YAMLEditingProcess(ArvObjLoadingHelper, ObjectEditingProcessBase):
     """Subclass of editing process tuned for YAML files."""
     _file_type = "YAML"
 

--- a/sdk/python/arvados/commands/arvcli.py
+++ b/sdk/python/arvados/commands/arvcli.py
@@ -519,8 +519,8 @@ class ArvObjLoadingHelper:
             raise EditingContentError(
                 path=path, file_type=self._file_type,
                 original_exception=ValueError(
-                    f"{self._file_type or 'unknown-format'} input has type"
-                    f" '{type(obj).__name__}', not a valid Arvados object"
+                    f"Input content type is '{type(obj).__name__}',"
+                    " not a valid Arvados object"
                 )
             )
         return obj

--- a/sdk/python/tests/test_arvcli.py
+++ b/sdk/python/tests/test_arvcli.py
@@ -1222,7 +1222,8 @@ class TestEditingSubcommands:
             exit_code, out, err = run_arvcli(["create", "group"])
 
         assert exit_code == 1
-        assert "JSON input has type 'list', not a valid Arvados object" in err
+        assert "Error: invalid input file [type JSON]" in err
+        assert "Input content type is 'list', not a valid Arvados object" in err
 
     def test_edit_malfomed_type_code_in_uuid(self, run_arvcli):
         exit_code, out, err = run_arvcli(["edit", TestArgTypes.bad_uuid])


### PR DESCRIPTION
`446-dry-up-arvcli-editing-subclasses` @ 6440d41cbdbcf304bcdb010b0923908c60d3fb74

https://ci.arvados.org/job/developer-run-tests/5111/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Minimally touch the base class `ObjectEditingProcessBase`
  * Unify file extension and file-type-name in error messages (this effectively only affects the YAML class only, as we used to have ".yml" for file extension but "YAML" in human-readable error messages.)
  * Refactor the deserialization code in JSON/YAML-editing sibling classes so both become much simpler and straightforward to understand.
  * No more `functools.partial()` call in the sibling class bodies that would cause a `FutureWarning` in Python 3.13 and outright error in 3.14.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Passes test suites with Python 3.10 -- 3.13.
  * Manual test: run `arvcli.py` with `create/edit` subcommands and observe editor behavior (file name, etc.) and UX.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * Mostly an internal implementation-detail change; no reader-facing doc change.
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * Yes

Closes #446.