### PR TITLE
450: Make `commands.ws.main()` NoReturn.

### DIFF
--- a/sdk/python/arvados/commands/ws.py
+++ b/sdk/python/arvados/commands/ws.py
@@ -105,6 +105,7 @@ def main(arguments=None):
         else:
             print(json.dumps(ev))
 
+    status = 0
     try:
         ws = subscribe(arvados.api('v1'), filters, on_message, poll_fallback=args.poll_interval, last_log_id=last_log_id)
         if ws:
@@ -117,7 +118,9 @@ def main(arguments=None):
     except KeyboardInterrupt:
         pass
     except Exception as e:
+        status = 1
         logger.error(e)
     finally:
         if ws:
             ws.close()
+        sys.exit(status)

--- a/sdk/python/tests/test_arv_ws.py
+++ b/sdk/python/tests/test_arv_ws.py
@@ -25,3 +25,14 @@ class ArvWsTestCase(unittest.TestCase, tutil.VersionChecker):
             with self.assertRaises(SystemExit):
                 self.run_ws(['--version'])
         self.assertVersionOutput(out, err)
+
+    def test_ctrl_c(self):
+        with (
+            self.assertRaises(SystemExit) as cm,
+            unittest.mock.patch(
+                "arvados.events.EventClient.run_forever",
+                unittest.mock.Mock(side_effect=KeyboardInterrupt)
+            )
+        ):
+            self.run_ws([])
+        self.assertEqual(cm.exception.code, 0)


### PR DESCRIPTION
`450-make-ws-command-main-function-NoReturn` @ 8dccc3a166c4964b30429e44cbd190e35ae2d0e4

https://ci.arvados.org/job/developer-run-tests/5117/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * The `arvados.commands.ws.main()` function normally sits in a "run forever" loop, with cleanup code in the exception handler and `finally` blocks. The new code sets the appropriate status and calls `sys.exit(status)` in those cleanup blocks.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * New unit test tests the behavior of `arv-ws` under `KeyboardInterrupt` (should exit with 0).
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * This change only affects how the client interacts with the user and the environment. Client-server relation is not affected.
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_ for new code.

This is a follow-up to the work in #436.

Closes #450.
Closes #432.