### PR TITLE
454: Improve cluster-activity argument parsing

### DIFF
--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -30,10 +30,10 @@ class _ArgTypes:
     """
     @staticmethod
     def date_arg(text: str | None = None) -> datetime:
-        """Convert input string in the form of YYYY-MM-DD to a UTC-timezone
-        datetime object for the specified date at 00h00m00s ("midnight").  If
-        the input is the empty string, return the midnight datetime of the
-        current UTC day.
+        """Converts the input string in the form of YYYY-MM-DD to a
+        UTC-timezone datetime object for the specified date at 00h00m00s
+        ("midnight"). When called without argument, returns the midnight
+        datetime of the current UTC day.
         """
         if text is None:
             dt_obj = datetime.now(timezone.utc)
@@ -54,7 +54,7 @@ class _ArgTypes:
 
     @staticmethod
     def positive_days(text: str) -> timedelta:
-        """Returns a timedelta of N days from the input string parsed as an
+        """Returns a timedelta of N days with the input string parsed as an
         integer. Negative values are invalid.
         """
         n = int(text)  # Let ValueError propagate.
@@ -64,7 +64,7 @@ class _ArgTypes:
 
     @staticmethod
     def n_days_before(src_arg: str) -> type[argparse.Action]:
-        """Make an `argparse.Action` subclass to be used by the "--days"
+        """Makes an `argparse.Action` subclass to be used by the "--days"
         argument. The returned subclass does the following:
             1. Take the value of the argument named `src_arg`;
             2. Subtract, from this `src_arg` value, the value of the argument
@@ -83,7 +83,7 @@ class _ArgTypes:
 
     @staticmethod
     def load_prometheus_auth(path: str) -> None:
-        """Load Prometheus environment variables from `path` into the current
+        """Loads Prometheus environment variables from `path` into the current
         process's `os.environ`.
         """
         prom_vars = {}

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -208,26 +208,26 @@ def get_prometheus_client():
         logging.warn("Connecting to Prometheus failed, will not collect activity from Prometheus.  Error was: %s" % e)
         return None
 
-def report_from_prometheus(prom, cluster, since, to):
+def report_from_prometheus(prom, cluster, start_time, end_time):
 
     if not cluster:
         arv_client = arvados.api()
         cluster = arv_client.config()["ClusterID"]
 
-    print(cluster, "between", since, "and", to, "timespan", (to-since))
+    print(cluster, "between", start_time, "and", end_time, "timespan", (end_time - start_time))
 
     try:
-        print_data_usage(prom, since, cluster, "at start:")
+        print_data_usage(prom, start_time, cluster, "at start:")
     except:
         logging.exception("Failed to get start value")
 
     try:
-        print_data_usage(prom, to - timedelta(minutes=240), cluster, "current :")
+        print_data_usage(prom, end_time - timedelta(minutes=240), cluster, "current :")
     except:
         logging.exception("Failed to get end value")
 
-    print_container_usage(prom, since, to, "arvados_dispatchcloud_containers_running{cluster='%s'}" % cluster, '%.1f container hours', lambda x: x/60)
-    print_container_usage(prom, since, to, "sum(arvados_dispatchcloud_instances_price{cluster='%s'})" % cluster, '$%.2f spent on compute', lambda x: x/60)
+    print_container_usage(prom, start_time, end_time, "arvados_dispatchcloud_containers_running{cluster='%s'}" % cluster, '%.1f container hours', lambda x: x/60)
+    print_container_usage(prom, start_time, end_time, "sum(arvados_dispatchcloud_instances_price{cluster='%s'})" % cluster, '$%.2f spent on compute', lambda x: x/60)
     print()
 
 

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -145,9 +145,15 @@ def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
         default=_ArgTypes.date_arg()  # Today.
     )
 
-    arg_parser.add_argument('--cost-report-file', type=str, help='Export cost report to specified CSV file')
-    arg_parser.add_argument('--include-workflow-steps', default=False,
-                            action="store_true", help='Include individual workflow steps in cost report (optional)')
+    arg_parser.add_argument(
+        '--cost-report-file',
+        help='Export cost report to specified CSV file',
+        metavar='PATH'
+    )
+    arg_parser.add_argument(
+        '--include-workflow-steps', default=False, action="store_true",
+        help='Include individual workflow steps in cost report (optional)'
+    )
     arg_parser.add_argument(
         '--columns',
         type=_ArgTypes.columns,
@@ -158,15 +164,30 @@ def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
         ),
         metavar="COLUMN[,COLUMN ...]"
     )
-    arg_parser.add_argument('--exclude', type=str, help="Exclude workflows containing this substring (may be a regular expression)")
+    arg_parser.add_argument(
+        '--exclude',
+        help=(
+            "Exclude workflows containing this substring"
+            " (may be a regular expression)"
+        ),
+        metavar="PATTERN"
+    )
 
-    arg_parser.add_argument('--html-report-file', type=str, help='Export HTML report to specified file')
+    arg_parser.add_argument(
+        '--html-report-file',
+        help='Export HTML report to specified file',
+        metavar='PATH'
+    )
     arg_parser.add_argument(
         '--version', action='version', version=f"%(prog)s {__version__}",
         help='Print version and exit.'
     )
 
-    arg_parser.add_argument('--cluster', type=str, help='Cluster to query for prometheus stats')
+    arg_parser.add_argument(
+        '--cluster',
+        help='Cluster to query for prometheus stats',
+        metavar='CLUSTER-ID'
+    )
     arg_parser.add_argument(
         '--prometheus-auth',
         type=_ArgTypes.load_prometheus_auth,

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -39,8 +39,9 @@ def parse_arguments(arguments):
 
     arg_parser.add_argument('--html-report-file', type=str, help='Export HTML report to specified file')
     arg_parser.add_argument(
-        '--version', action='version', version="%s %s" % (sys.argv[0], __version__),
-        help='Print version and exit.')
+        '--version', action='version', version=f"%(prog)s {__version__}",
+        help='Print version and exit.'
+    )
 
     arg_parser.add_argument('--cluster', type=str, help='Cluster to query for prometheus stats')
     arg_parser.add_argument('--prometheus-auth', type=str, help='Authorization file with prometheus info')

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -8,7 +8,6 @@ import base64
 from datetime import timedelta, timezone, datetime
 import logging
 import os
-import sys
 
 prometheus_import_error = None
 try:

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -18,7 +18,7 @@ except ImportError as e:
 
 import arvados
 
-from arvados_cluster_activity.report import ClusterActivityReport, aws_monthly_cost, bytes_base2_fmt
+from arvados_cluster_activity.report import ClusterActivityReport, aws_monthly_cost, bytes_base2_fmt, WorkflowRunCSVRow
 from arvados_cluster_activity.prometheus import get_metric_usage, get_data_usage
 from arvados_cluster_activity._version import __version__
 
@@ -101,19 +101,16 @@ class _ArgTypes:
         os.environ.update(prom_vars)
         return path
 
-    VALID_COLUMNS = frozenset((
-        'Project', 'ProjectUUID', 'Workflow', 'WorkflowUUID', 'Step',
-        'StepUUID', 'Sample', 'SampleUUID', 'User', 'UserUUID', 'Submitted',
-        'Started', 'Runtime', 'Cost'
-    ))
+    VALID_FIELDS = WorkflowRunCSVRow.field_names()
 
     @staticmethod
     def columns(text: str) -> tuple[str]:
         # We can be more lenient with space characters around commas, but still
         # expect the arg value as one string, for compatibility.
+        valid_fields = frozenset(_ArgTypes.VALID_FIELDS)
         result = []
         for elem in map(str.strip, text.split(",")):
-            if elem not in _ArgTypes.VALID_COLUMNS:
+            if elem not in valid_fields:
                 raise ValueError(f"invalid column name: {elem!r}")
             result.append(elem)
         return tuple(result)
@@ -156,9 +153,8 @@ def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
         type=_ArgTypes.columns,
         help=(
             "Cost report columns (optional), must be comma separated with no"
-            " spaces between column names.  Available columns are: Project,"
-            " ProjectUUID, Workflow, WorkflowUUID, Step, StepUUID, Sample,"
-            " SampleUUID, User, UserUUID, Submitted, Started, Runtime, Cost."
+            " spaces between column names.  Available columns are:"
+            f" {', '.join(_ArgTypes.VALID_FIELDS)}."
         ),
         metavar="COLUMN[,COLUMN ...]"
     )

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -257,7 +257,7 @@ def main(arguments=None):
         logging.info("Use --html-report-file to get HTML report of cluster usage")
 
     if not args.cost_report_file and not args.html_report_file:
-        report_from_prometheus(prom, args.cluster, args.start, args.end)
+        report_from_prometheus(prom_client, args.cluster, args.start, args.end)
 
 if __name__ == "__main__":
     main()

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -10,9 +10,11 @@ import logging
 import os
 import sys
 
+prometheus_import_error = None
 try:
     from prometheus_api_client import PrometheusConnect
 except ImportError as e:
+    prometheus_import_error = e
     PrometheusConnect = None
 
 import arvados
@@ -86,7 +88,7 @@ def parse_arguments(arguments):
         with open(args.prometheus_auth, "rt") as f:
             for line in f:
                 if line.startswith("export "):
-                   line = line[7:]
+                    line = line[7:]
                 sp = line.strip().split("=")
                 if sp[0].startswith("PROMETHEUS_"):
                     os.environ[sp[0]] = sp[1]
@@ -121,7 +123,7 @@ def print_container_usage(prom, start_time, end_time, metric, label, fn=None):
 
 def get_prometheus_client():
     if PrometheusConnect is None:
-        logging.warn("Failed to import prometheus_api_client client.  Did you include the [prometheus] option when installing the package?  Error was: %s" % e)
+        logging.warn("Failed to import prometheus_api_client client.  Did you include the [prometheus] option when installing the package?  Error was: %s" % prometheus_import_error)
         return None
 
     headers = {}

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -82,7 +82,7 @@ class _ArgTypes:
         return SubtractFromSrc
 
     @staticmethod
-    def load_prometheus_auth(path: str) -> None:
+    def load_prometheus_auth(path: str) -> str:
         """Loads Prometheus environment variables from `path` into the current
         process's `os.environ`.
 

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -17,7 +17,6 @@ except ImportError as e:
     PrometheusConnect = None
 
 import arvados
-import arvados.util
 
 from arvados_cluster_activity.report import ClusterActivityReport, aws_monthly_cost, bytes_base2_fmt
 from arvados_cluster_activity.prometheus import get_metric_usage, get_data_usage
@@ -102,6 +101,23 @@ class _ArgTypes:
         os.environ.update(prom_vars)
         return path
 
+    VALID_COLUMNS = frozenset((
+        'Project', 'ProjectUUID', 'Workflow', 'WorkflowUUID', 'Step',
+        'StepUUID', 'Sample', 'SampleUUID', 'User', 'UserUUID', 'Submitted',
+        'Started', 'Runtime', 'Cost'
+    ))
+
+    @staticmethod
+    def columns(text: str) -> tuple[str]:
+        # We can be more lenient with space characters around commas, but still
+        # expect the arg value as one string, for compatibility.
+        result = []
+        for elem in map(str.strip, text.split(",")):
+            if elem not in _ArgTypes.VALID_COLUMNS:
+                raise ValueError(f"invalid column name: {elem!r}")
+            result.append(elem)
+        return tuple(result)
+
 
 def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
     arg_parser = argparse.ArgumentParser(prog=prog)
@@ -135,8 +151,17 @@ def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
     arg_parser.add_argument('--cost-report-file', type=str, help='Export cost report to specified CSV file')
     arg_parser.add_argument('--include-workflow-steps', default=False,
                             action="store_true", help='Include individual workflow steps in cost report (optional)')
-    arg_parser.add_argument('--columns', type=str, help="""Cost report columns (optional), must be comma separated with no spaces between column names.
-    Available columns are: Project, ProjectUUID, Workflow, WorkflowUUID, Step, StepUUID, Sample, SampleUUID, User, UserUUID, Submitted, Started, Runtime, Cost""")
+    arg_parser.add_argument(
+        '--columns',
+        type=_ArgTypes.columns,
+        help=(
+            "Cost report columns (optional), must be comma separated with no"
+            " spaces between column names.  Available columns are: Project,"
+            " ProjectUUID, Workflow, WorkflowUUID, Step, StepUUID, Sample,"
+            " SampleUUID, User, UserUUID, Submitted, Started, Runtime, Cost."
+        ),
+        metavar="COLUMN[,COLUMN ...]"
+    )
     arg_parser.add_argument('--exclude', type=str, help="Exclude workflows containing this substring (may be a regular expression)")
 
     arg_parser.add_argument('--html-report-file', type=str, help='Export HTML report to specified file')

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -25,11 +25,111 @@ from arvados_cluster_activity.prometheus import get_metric_usage, get_data_usage
 from arvados_cluster_activity._version import __version__
 
 
-def parse_arguments(arguments):
-    arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--start', help='Start date for the report in YYYY-MM-DD format (UTC) (or use --days)')
-    arg_parser.add_argument('--end', help='End date for the report in YYYY-MM-DD format (UTC), default "now"')
-    arg_parser.add_argument('--days', type=int, help='Number of days before "end" to start the report (or use --start)')
+class _ArgTypes:
+    """Namespace class that holds types and utilities for argument parsing
+    and validation.
+    """
+    @staticmethod
+    def date_arg(text: str | None = None) -> datetime:
+        """Convert input string in the form of YYYY-MM-DD to a UTC-timezone
+        datetime object for the specified date at 00h00m00s ("midnight").  If
+        the input is the empty string, return the midnight datetime of the
+        current UTC day.
+        """
+        if text is None:
+            dt_obj = datetime.now(timezone.utc)
+        else:
+            try:
+                dt_obj = datetime.strptime(text, "%Y-%m-%d")
+            except ValueError:
+                # strptime may raise ValueError with a cryptic message, e.g.
+                # strptime("2026-01-32", "%Y-%m-%d") -> "unconverted data
+                # remains: 2" (tested in Pythons 3.10 -- 3.13), so we provide a
+                # clear and fiendly message.
+                raise argparse.ArgumentTypeError(
+                    f"invalid date: {text!r}"
+                ) from None
+        return dt_obj.replace(
+            hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
+        )
+
+    @staticmethod
+    def positive_days(text: str) -> timedelta:
+        """Returns a timedelta of N days from the input string parsed as an
+        integer. Negative values are invalid.
+        """
+        n = int(text)  # Let ValueError propagate.
+        if n < 0:
+            raise ValueError(f"not a positive integer: {text!r}")
+        return timedelta(days=n)
+
+    @staticmethod
+    def n_days_before(src_arg: str) -> type[argparse.Action]:
+        """Make an `argparse.Action` subclass to be used by the "--days"
+        argument. The returned subclass does the following:
+            1. Take the value of the argument named `src_arg`;
+            2. Subtract, from this `src_arg` value, the value of the argument
+               that uses this action; and then,
+            3. Store the subtraction result to the `dest` of the argument that
+               uses this action.
+        """
+        class SubtractFromSrc(argparse.Action):
+            __src = src_arg
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                src_value = getattr(namespace, self.__src)
+                setattr(namespace, self.dest, src_value - values)
+
+        return SubtractFromSrc
+
+    @staticmethod
+    def load_prometheus_auth(path: str) -> None:
+        """Load Prometheus environment variables from `path` into the current
+        process's `os.environ`.
+        """
+        prom_vars = {}
+        try:
+            with open(path, "rt") as f:
+                for line in f:
+                    if line.startswith("export "):
+                        line = line[7:]
+                    sp = line.strip().split("=")
+                    if sp[0].startswith("PROMETHEUS_"):
+                        prom_vars[sp[0]] = sp[1]
+        except OSError as err:
+            raise argparse.ArgumentTypeError(str(err)) from None
+        os.environ.update(prom_vars)
+
+
+def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    arg_parser = argparse.ArgumentParser(prog=prog)
+
+    start_date_group = arg_parser.add_mutually_exclusive_group(required=True)
+    start_date_group.add_argument(
+        '--start',
+        type=_ArgTypes.date_arg,
+        help='Start date for the report in YYYY-MM-DD format (UTC)',
+        metavar="DATE"
+    )
+    start_date_group.add_argument(
+        '--days',
+        type=_ArgTypes.positive_days,
+        dest="start",
+        action=_ArgTypes.n_days_before("end"),
+        help='Number of days before "end" to start the report',
+        metavar="N"
+    )
+    arg_parser.add_argument(
+        '--end',
+        type=_ArgTypes.date_arg,
+        help=(
+            'End date for the report in YYYY-MM-DD format (UTC);'
+            ' Default: today'
+        ),
+        metavar="DATE",
+        default=_ArgTypes.date_arg()  # Today.
+    )
+
     arg_parser.add_argument('--cost-report-file', type=str, help='Export cost report to specified CSV file')
     arg_parser.add_argument('--include-workflow-steps', default=False,
                             action="store_true", help='Include individual workflow steps in cost report (optional)')
@@ -44,57 +144,15 @@ def parse_arguments(arguments):
     )
 
     arg_parser.add_argument('--cluster', type=str, help='Cluster to query for prometheus stats')
-    arg_parser.add_argument('--prometheus-auth', type=str, help='Authorization file with prometheus info')
+    arg_parser.add_argument(
+        '--prometheus-auth',
+        type=_ArgTypes.load_prometheus_auth,
+        help='Authorization file with prometheus info',
+        metavar='PATH'
+    )
 
-    args = arg_parser.parse_args(arguments)
+    return arg_parser
 
-    if args.days and args.start:
-        arg_parser.print_help()
-        print("Error: either specify --days or both --start and --end")
-        exit(1)
-
-    if not args.days and not args.start:
-        arg_parser.print_help()
-        print("\nError: either specify --days or both --start and --end")
-        exit(1)
-
-    if (args.start and not args.end):
-        arg_parser.print_help()
-        print("\nError: no start or end date found, either specify --days or both --start and --end")
-        exit(1)
-
-    if args.end:
-        try:
-            to = datetime.strptime(args.end,"%Y-%m-%d")
-        except:
-            arg_parser.print_help()
-            print("\nError: end date must be in YYYY-MM-DD format")
-            exit(1)
-    else:
-        to = datetime.now(timezone.utc)
-
-    if args.days:
-        since = to - timedelta(days=args.days)
-
-    if args.start:
-        try:
-            since = datetime.strptime(args.start,"%Y-%m-%d")
-        except:
-            arg_parser.print_help()
-            print("\nError: start date must be in YYYY-MM-DD format")
-            exit(1)
-
-
-    if args.prometheus_auth:
-        with open(args.prometheus_auth, "rt") as f:
-            for line in f:
-                if line.startswith("export "):
-                    line = line[7:]
-                sp = line.strip().split("=")
-                if sp[0].startswith("PROMETHEUS_"):
-                    os.environ[sp[0]] = sp[1]
-
-    return args, since, to
 
 def print_data_usage(prom, timestamp, cluster, label):
     value, dedup_ratio = get_data_usage(prom, timestamp, cluster)
@@ -172,10 +230,8 @@ def report_from_prometheus(prom, cluster, since, to):
 
 
 def main(arguments=None):
-    if arguments is None:
-        arguments = sys.argv[1:]
-
-    args, since, to = parse_arguments(arguments)
+    parser = get_argument_parser()
+    args = parser.parse_args(arguments)
 
     logging.basicConfig(
         level=logging.INFO,
@@ -183,8 +239,8 @@ def main(arguments=None):
 
     prom_client = get_prometheus_client()
     reporter = ClusterActivityReport(
-        since,
-        to,
+        args.start,
+        args.end,
         prom_client=prom_client,
         exclude=args.exclude,
     )
@@ -201,7 +257,7 @@ def main(arguments=None):
         logging.info("Use --html-report-file to get HTML report of cluster usage")
 
     if not args.cost_report_file and not args.html_report_file:
-        report_from_prometheus(prom, args.cluster, since, to)
+        report_from_prometheus(prom, args.cluster, args.start, args.end)
 
 if __name__ == "__main__":
     main()

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -85,6 +85,8 @@ class _ArgTypes:
     def load_prometheus_auth(path: str) -> None:
         """Loads Prometheus environment variables from `path` into the current
         process's `os.environ`.
+
+        Returns `path` unmodified if the operation succeeds.
         """
         prom_vars = {}
         try:
@@ -98,6 +100,7 @@ class _ArgTypes:
         except OSError as err:
             raise argparse.ArgumentTypeError(str(err)) from None
         os.environ.update(prom_vars)
+        return path
 
 
 def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -62,25 +62,6 @@ class _ArgTypes:
         return timedelta(days=n)
 
     @staticmethod
-    def n_days_before(src_arg: str) -> type[argparse.Action]:
-        """Makes an `argparse.Action` subclass to be used by the "--days"
-        argument. The returned subclass does the following:
-            1. Take the value of the argument named `src_arg`;
-            2. Subtract, from this `src_arg` value, the value of the argument
-               that uses this action; and then,
-            3. Store the subtraction result to the `dest` of the argument that
-               uses this action.
-        """
-        class SubtractFromSrc(argparse.Action):
-            __src = src_arg
-
-            def __call__(self, parser, namespace, values, option_string=None):
-                src_value = getattr(namespace, self.__src)
-                setattr(namespace, self.dest, src_value - values)
-
-        return SubtractFromSrc
-
-    @staticmethod
     def load_prometheus_auth(path: str) -> str:
         """Loads Prometheus environment variables from `path` into the current
         process's `os.environ`.
@@ -129,8 +110,6 @@ def get_argument_parser(prog: str | None = None) -> argparse.ArgumentParser:
     start_date_group.add_argument(
         '--days',
         type=_ArgTypes.positive_days,
-        dest="start",
-        action=_ArgTypes.n_days_before("end"),
         help='Number of days before "end" to start the report',
         metavar="N"
     )
@@ -276,6 +255,8 @@ def report_from_prometheus(prom, cluster, start_time, end_time):
 def main(arguments=None):
     parser = get_argument_parser()
     args = parser.parse_args(arguments)
+    if args.start is None:
+        args.start = args.end - args.days
 
     logging.basicConfig(
         level=logging.INFO,

--- a/tools/cluster-activity/arvados_cluster_activity/main.py
+++ b/tools/cluster-activity/arvados_cluster_activity/main.py
@@ -4,28 +4,24 @@
 # SPDX-License-Identifier: AGPL-3.0
 
 import argparse
-import sys
-
-import arvados
-import arvados.util
-import ciso8601
-import csv
-import os
+import base64
+from datetime import timedelta, timezone, datetime
 import logging
-import re
+import os
+import sys
 
 try:
     from prometheus_api_client import PrometheusConnect
 except ImportError as e:
     PrometheusConnect = None
 
+import arvados
+import arvados.util
+
 from arvados_cluster_activity.report import ClusterActivityReport, aws_monthly_cost, bytes_base2_fmt
 from arvados_cluster_activity.prometheus import get_metric_usage, get_data_usage
-
 from arvados_cluster_activity._version import __version__
 
-from datetime import timedelta, timezone, datetime
-import base64
 
 def parse_arguments(arguments):
     arg_parser = argparse.ArgumentParser()

--- a/tools/cluster-activity/arvados_cluster_activity/report.py
+++ b/tools/cluster-activity/arvados_cluster_activity/report.py
@@ -99,6 +99,33 @@ def aws_monthly_cost(value):
 
 
 @dataclasses.dataclass(slots=True)
+class WorkflowRunCSVRow:
+    Project: str
+    ProjectUUID: str
+    Workflow: str
+    WorkflowUUID: str
+    Step: str
+    StepUUID: str
+    Sample: str
+    SampleUUID: str
+    User: str
+    UserUUID: str
+    Submitted: str
+    Started: str
+    Finished: str
+    Runtime: str
+    Cost: str
+    CumulativeCost: str
+
+    def asdict(self, **kwargs) -> dict[str, str]:
+        return dataclasses.asdict(self, **kwargs)
+
+    @classmethod
+    def field_names(cls) -> tuple[str]:
+        return tuple(map(lambda f: f.name, dataclasses.fields(cls)))
+
+
+@dataclasses.dataclass(slots=True)
 class WorkflowRun:
     """Encapsulate and query a run container
 
@@ -187,26 +214,26 @@ class WorkflowRun:
         else:
             return self.template_uuid(default)
 
-    def csv_row(self):
+    def csv_row(self) -> dict[str, str]:
         started, finished, runtime = self.start_end_runtime()
-        return {
-            'Project': self.owner_name(),
-            'ProjectUUID': self.request['owner_uuid'],
-            'Workflow': self.workflow_name('workflow run from command line'),
-            'WorkflowUUID': self.template_uuid('none'),
-            'Step': self.step_name(),
-            'StepUUID': self.request['uuid'],
-            'Sample': self.request['name'],
-            'SampleUUID': self.request['uuid'],
-            'User': self.user_name(),
-            'UserUUID': self.request['modified_by_user_uuid'],
-            'Submitted': datetime_fmt(self.created_at()),
-            'Started': datetime_fmt(started),
-            'Finished': datetime_fmt(finished),
-            'Runtime': duration_hms_fmt(runtime),
-            'Cost': self.container_cost(),
-            'CumulativeCost': self.cumulative_cost(),
-        }
+        return WorkflowRunCSVRow(
+            Project=self.owner_name(),
+            ProjectUUID=self.request['owner_uuid'],
+            Workflow=self.workflow_name('workflow run from command line'),
+            WorkflowUUID=self.template_uuid('none'),
+            Step=self.step_name(),
+            StepUUID=self.request['uuid'],
+            Sample=self.request['name'],
+            SampleUUID=self.request['uuid'],
+            User=self.user_name(),
+            UserUUID=self.request['modified_by_user_uuid'],
+            Submitted=datetime_fmt(self.created_at()),
+            Started=datetime_fmt(started),
+            Finished=datetime_fmt(finished),
+            Runtime=duration_hms_fmt(runtime),
+            Cost=self.container_cost(),
+            CumulativeCost=self.cumulative_cost(),
+        ).asdict()
 
 
 @dataclasses.dataclass(slots=True)

--- a/tools/cluster-activity/arvados_cluster_activity/report.py
+++ b/tools/cluster-activity/arvados_cluster_activity/report.py
@@ -122,7 +122,7 @@ class WorkflowRunCSVRow:
 
     @classmethod
     def field_names(cls) -> tuple[str]:
-        return tuple(map(lambda f: f.name, dataclasses.fields(cls)))
+        return tuple(f.name for f in dataclasses.fields(cls))
 
 
 @dataclasses.dataclass(slots=True)

--- a/tools/cluster-activity/arvados_cluster_activity/report.py
+++ b/tools/cluster-activity/arvados_cluster_activity/report.py
@@ -117,9 +117,6 @@ class WorkflowRunCSVRow:
     Cost: str
     CumulativeCost: str
 
-    def asdict(self, **kwargs) -> dict[str, str]:
-        return dataclasses.asdict(self, **kwargs)
-
     @classmethod
     def field_names(cls) -> tuple[str]:
         return tuple(f.name for f in dataclasses.fields(cls))
@@ -216,7 +213,7 @@ class WorkflowRun:
 
     def csv_row(self) -> dict[str, str]:
         started, finished, runtime = self.start_end_runtime()
-        return WorkflowRunCSVRow(
+        return dataclasses.asdict(WorkflowRunCSVRow(
             Project=self.owner_name(),
             ProjectUUID=self.request['owner_uuid'],
             Workflow=self.workflow_name('workflow run from command line'),
@@ -233,7 +230,7 @@ class WorkflowRun:
             Runtime=duration_hms_fmt(runtime),
             Cost=self.container_cost(),
             CumulativeCost=self.cumulative_cost(),
-        ).asdict()
+        ))
 
 
 @dataclasses.dataclass(slots=True)
@@ -872,13 +869,16 @@ class ClusterActivityReport:
 
     def csv_report(self, out, columns, *, include_steps: bool):
         if not columns:
-            columns = ((
-                "Project", "Workflow", "Step",
-                "Sample", "User", "Submitted", "Runtime", "Cost"
-            ) if include_steps else (
-                "Project", "Workflow",
-                "Sample", "User", "Submitted", "Runtime", "CumulativeCost"
-            ))
+            if include_steps:
+                columns = (
+                    "Project", "Workflow", "Step",
+                    "Sample", "User", "Submitted", "Runtime", "Cost"
+                )
+            else:
+                columns = (
+                    "Project", "Workflow",
+                    "Sample", "User", "Submitted", "Runtime", "CumulativeCost"
+                )
 
         csvwriter = csv.DictWriter(out, fieldnames=columns, extrasaction="ignore")
         csvwriter.writeheader()

--- a/tools/cluster-activity/arvados_cluster_activity/report.py
+++ b/tools/cluster-activity/arvados_cluster_activity/report.py
@@ -844,12 +844,14 @@ class ClusterActivityReport:
         ).html()
 
     def csv_report(self, out, columns, *, include_steps: bool):
-        if columns:
-            columns = columns.split(",")
-        elif include_steps:
-            columns = ("Project", "Workflow", "Step", "Sample", "User", "Submitted", "Runtime", "Cost")
-        else:
-            columns = ("Project", "Workflow", "Sample", "User", "Submitted", "Runtime", "CumulativeCost")
+        if not columns:
+            columns = ((
+                "Project", "Workflow", "Step",
+                "Sample", "User", "Submitted", "Runtime", "Cost"
+            ) if include_steps else (
+                "Project", "Workflow",
+                "Sample", "User", "Submitted", "Runtime", "CumulativeCost"
+            ))
 
         csvwriter = csv.DictWriter(out, fieldnames=columns, extrasaction="ignore")
         csvwriter.writeheader()

--- a/tools/cluster-activity/tests/test_main.py
+++ b/tools/cluster-activity/tests/test_main.py
@@ -1,8 +1,16 @@
 # Copyright (C) The Arvados Authors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+import argparse
+import datetime
+import os
 import re
 import subprocess
+from unittest.mock import patch
+
+import pytest
+
+import arvados_cluster_activity.main as aca_main
 
 
 class TestSanity:
@@ -41,3 +49,94 @@ class TestSanity:
         assert completed_process.returncode == 2
         assert not completed_process.stdout
         assert f"usage: {self.script}" in completed_process.stderr
+
+
+class TestDateArgs:
+    @pytest.mark.parametrize("date", (
+        "0001-01-01", "1900-01-01", "1999-12-31", "2020-02-29"
+    ))
+    def test_valid_date_arg(self, date):
+        y, m, d = map(int, date.split("-"))
+        actual = aca_main._ArgTypes.date_arg(date)
+        assert actual.tzinfo == datetime.timezone.utc
+        assert actual.year == y
+        assert actual.month == m
+        assert actual.day == d
+        assert actual.time() == datetime.time(0)
+
+    @pytest.mark.parametrize("invalid_date", (
+        "1900-02-29", "1999-11-31", "2026-13-01", "2026-01-42",
+        "2026-07-21T12:34:56.7890Z", "foo", "1-1-1", "2025-DEC-31"
+    ))
+    def test_invalid_date_arg(self, invalid_date):
+        with pytest.raises(
+            argparse.ArgumentTypeError,
+            match=re.compile(
+                rf"^invalid date: {re.escape(repr(invalid_date))}$"
+            )
+        ):
+            aca_main._ArgTypes.date_arg(invalid_date)
+
+    def test_today_date_arg(self):
+        now = "1987-01-23T23:45:06.789-10:00"
+        expected = "1987-01-24T00:00:00+00:00"  # start of UTC day
+
+        fake_now = datetime.datetime.fromisoformat(now).astimezone(
+            datetime.timezone.utc
+        )
+        orig_replace = datetime.datetime.replace
+        with patch("arvados_cluster_activity.main.datetime") as m:
+            m.now.return_value = fake_now
+            m.replace = orig_replace
+            actual = aca_main._ArgTypes.date_arg()
+        assert actual == datetime.datetime.fromisoformat(expected)
+
+    @pytest.mark.parametrize("invalid_input", ("-1", "0x01", "foo"))
+    def test_invalid_positive_days(self, invalid_input):
+        with pytest.raises(ValueError):
+            aca_main._ArgTypes.positive_days(invalid_input)
+
+
+def test_n_days_before():
+    ns = argparse.Namespace()
+    ns.foo = 42
+    action_class_on_foo = aca_main._ArgTypes.n_days_before("foo")
+    action_instance = action_class_on_foo(["--whatever", "-w"], "bar")
+    n = 1
+    action_instance(None, ns, n, "-w")
+    assert ns.bar == ns.foo - n
+
+
+class TestLoadPrometheusAuth:
+    def test_valid(self, tmp_path):
+        key = "PROMETHEUS_FOO"
+        val = "BAR"
+        filler = "FOO"
+        export_key = "PROMETHEUS_A"
+        export_val = "B"
+        prom_file = tmp_path / "prom"
+        prom_file.write_text(
+            f"{key}={val}\n"
+            f"{filler}\n"
+            f"export {export_key}={export_val}\n"
+        )
+        with patch("os.environ", {}):
+            aca_main._ArgTypes.load_prometheus_auth(str(prom_file))
+            assert os.environ == {key: val, export_key: export_val}
+
+    def test_bad_path(self, tmp_path):
+        old_environ = os.environ.copy()
+        with pytest.raises(argparse.ArgumentTypeError):
+            aca_main._ArgTypes.load_prometheus_auth(f"{tmp_path!s}/no_file")
+        assert os.environ == old_environ
+
+
+class TestGetArgumentParser:
+    parser = aca_main.get_argument_parser()
+
+    def test_default_end_with_days(self):
+        n_days = 1
+        args = self.parser.parse_args(["--days", f"{n_days!s}"])
+        assert isinstance(args.end, datetime.datetime)
+        assert isinstance(args.start, datetime.datetime)
+        assert (args.end - args.start).days == n_days

--- a/tools/cluster-activity/tests/test_main.py
+++ b/tools/cluster-activity/tests/test_main.py
@@ -1,0 +1,43 @@
+# Copyright (C) The Arvados Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+import re
+import subprocess
+
+
+class TestSanity:
+    """Test that the `arv-cluster-activity` script is installed and can be
+    run as a standalone CLI app, that it understands the "-h" and "--version"
+    CLI arguments, and that it exits with status 2 upon invalid CLI arguments.
+    """
+    script = "arv-cluster-activity"
+
+    def run(self, *args, **kwargs) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [self.script, *args],
+            capture_output=True, text=True, check=False, **kwargs
+        )
+
+    def test_help(self):
+        completed_process = self.run("-h")
+        assert completed_process.returncode == 0
+        assert f"usage: {self.script}" in completed_process.stdout
+        assert not completed_process.stderr
+
+    def test_version(self):
+        completed_process = self.run("--version")
+        assert completed_process.returncode == 0
+        assert re.match(
+            (
+                rf"^{re.escape(self.script)}"
+                r" [0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?$\n"
+            ),
+            completed_process.stdout
+        )
+        assert not completed_process.stderr
+
+    def test_invalid_argument(self):
+        completed_process = self.run("--x-invalid-argument")
+        assert completed_process.returncode == 2
+        assert not completed_process.stdout
+        assert f"usage: {self.script}" in completed_process.stderr

--- a/tools/cluster-activity/tests/test_main.py
+++ b/tools/cluster-activity/tests/test_main.py
@@ -1,6 +1,6 @@
 # Copyright (C) The Arvados Authors. All rights reserved.
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: AGPL-3.0
 import argparse
 import datetime
 import os

--- a/tools/cluster-activity/tests/test_main.py
+++ b/tools/cluster-activity/tests/test_main.py
@@ -131,6 +131,14 @@ class TestLoadPrometheusAuth:
         assert os.environ == old_environ
 
 
+def test_invalid_columns():
+    with pytest.raises(
+        ValueError,
+        match=rf"^invalid column name: {repr('Foo')}$"
+    ):
+        aca_main._ArgTypes.columns("Workflow,Foo,User")
+
+
 class TestGetArgumentParser:
     parser = aca_main.get_argument_parser()
 

--- a/tools/cluster-activity/tests/test_main.py
+++ b/tools/cluster-activity/tests/test_main.py
@@ -97,16 +97,6 @@ class TestDateArgs:
             aca_main._ArgTypes.positive_days(invalid_input)
 
 
-def test_n_days_before():
-    ns = argparse.Namespace()
-    ns.foo = 42
-    action_class_on_foo = aca_main._ArgTypes.n_days_before("foo")
-    action_instance = action_class_on_foo(["--whatever", "-w"], "bar")
-    n = 1
-    action_instance(None, ns, n, "-w")
-    assert ns.bar == ns.foo - n
-
-
 class TestLoadPrometheusAuth:
     def test_valid(self, tmp_path):
         key = "PROMETHEUS_FOO"
@@ -139,12 +129,18 @@ def test_invalid_columns():
         aca_main._ArgTypes.columns("Workflow,Foo,User")
 
 
-class TestGetArgumentParser:
-    parser = aca_main.get_argument_parser()
-
-    def test_default_end_with_days(self):
-        n_days = 1
-        args = self.parser.parse_args(["--days", f"{n_days!s}"])
-        assert isinstance(args.end, datetime.datetime)
-        assert isinstance(args.start, datetime.datetime)
-        assert (args.end - args.start) == datetime.timedelta(days=n_days)
+def test_main_with_args_end_and_days():
+    n_days = 1
+    end = "2026-01-01"
+    expected_end = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    expected_start = expected_end - datetime.timedelta(days=n_days)
+    with (
+        patch("arvados_cluster_activity.main.ClusterActivityReport") as m,
+        patch("arvados_cluster_activity.main.get_prometheus_client") as gpc
+    ):
+        gpc.return_value = None
+        aca_main.main(["--days", str(n_days), "--end", end])
+    m.assert_called_once()
+    m.assert_called_with(
+        expected_start, expected_end, prom_client=None, exclude=None
+    )

--- a/tools/cluster-activity/tests/test_main.py
+++ b/tools/cluster-activity/tests/test_main.py
@@ -139,4 +139,4 @@ class TestGetArgumentParser:
         args = self.parser.parse_args(["--days", f"{n_days!s}"])
         assert isinstance(args.end, datetime.datetime)
         assert isinstance(args.start, datetime.datetime)
-        assert (args.end - args.start).days == n_days
+        assert (args.end - args.start) == datetime.timedelta(days=n_days)


### PR DESCRIPTION
`454-cluster-activity-argument-parsing` @ 303d6152d0224a7304997c10877554aeeb2c2b14

https://ci.arvados.org/job/developer-run-tests/5130/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Custom types are used to convert and validate the CLI options `--start`|`--days`, `--end`, `--prometheus-auth`, and `--columns`
    * For the date arguments, the logic of mutual-exclusion, default, and conversion is implemented using the machinery of `argparse` and completed during the arg parsing.
    * Valid values for `--columns` are no longer hard-coded. They now automatically sync with the keys returned by `report.WorkflowRun.csv_row`.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Tests have been added and they're passing.
  * Manual test: inspecting the output of `arv-cluster-activity` usage and error messages to gauge the CLI UX.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_ (the changes are functionally compatible and doesn't require changing user instructions)
* Behaves appropriately at the intended scale (describe intended scale).
  * There _may_ be some penalty if a truly large number of CSV rows are to be written, because `report.WorkflowRun.csv_row` has become more complex, with the creation and destruction of the small, ephemeral dataclass instances (partly mitigated, for spatial efficiency, by the use of `@dataclass(slots=True)`). However, I suspect that the real speed bottleneck is the writing I/O itself, and that Python's object memory management should cope well with these small objects.
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * Yes for new code.

This PR also includes small fixes (descriptive names, etc.)

Closes #454.