### PR TITLE
464: Replace `PyYAML` with `ruamel.yaml` in run_test_server.py.

### DIFF
--- a/build/requirements.tests.txt
+++ b/build/requirements.tests.txt
@@ -7,9 +7,8 @@
 ### Requirements for run-tests.sh itself
 -r requirements.build.txt
 
-# Required by sdk/python/tests/run_test_server.py
-# which is run directly by run-tests.sh
-PyYAML
+# YAML support required by sdk/python/tests/run_test_server.py is already
+# provided by the PySDK dependency ruamel.yaml
 
 # yq is used by run-tests.sh directly and controller tests
 yq ~= 3.4

--- a/sdk/python/tests/run_test_server.py
+++ b/sdk/python/tests/run_test_server.py
@@ -19,7 +19,10 @@ import sys
 import tempfile
 import time
 import unittest
-import yaml
+
+from ruamel.yaml import YAML
+yaml = YAML(typ="safe", pure=True)
+yaml.default_flow_style = False
 
 from urllib.parse import urlparse
 
@@ -456,7 +459,7 @@ def stop(force=False):
 
 def get_config():
     with open(os.environ["ARVADOS_CONFIG"]) as f:
-        return yaml.safe_load(f)
+        return yaml.load(f)
 
 def internal_port_from_config(service, idx=0):
     return int(urlparse(
@@ -565,7 +568,7 @@ def _start_keep(n, blob_signing=False):
     confdata = get_config()
     confdata['Clusters']['zzzzz']['Collections']['BlobSigning'] = blob_signing
     with open(conf, 'w') as f:
-        yaml.safe_dump(confdata, f)
+        yaml.dump(confdata, f)
     keep_cmd = ["arvados-server", "keepstore", "-config", conf]
 
     # Tell keepstore which of the InternalURLs it's supposed to listen
@@ -772,7 +775,7 @@ def setup_config():
     if configsrc:
         clusterconf = os.path.join(configsrc, "config.yml")
         print("Getting config from %s" % clusterconf, file=sys.stderr)
-        pgconnection = yaml.safe_load(open(clusterconf))["Clusters"]["zzzzz"]["PostgreSQL"]["Connection"]
+        pgconnection = yaml.load(open(clusterconf))["Clusters"]["zzzzz"]["PostgreSQL"]["Connection"]
     else:
         # assume the conventional db credentials
         pgconnection = {
@@ -938,7 +941,7 @@ def setup_config():
 
     conf = os.path.join(TEST_TMPDIR, 'arvados.yml')
     with open(conf, 'w') as f:
-        yaml.safe_dump(config, f)
+        yaml.dump(config, f)
 
     ex = "export ARVADOS_CONFIG="+conf
     print(ex)
@@ -962,7 +965,7 @@ def fixture(fix):
           yaml_file = yaml_file[0:trim_index]
         except ValueError:
           pass
-        return yaml.safe_load(yaml_file)
+        return yaml.load(yaml_file)
 
 def auth_token(token_name):
     return fixture("api_client_authorizations")[token_name]["api_token"]

--- a/services/api/test/fixtures/container_requests.yml
+++ b/services/api/test/fixtures/container_requests.yml
@@ -125,7 +125,6 @@ completed:
   runtime_constraints:
     vcpus: 1
     ram: 123
-  mounts: {}
 
 completed-older:
   uuid: zzzzz-xvhdp-cr4completedcr2
@@ -151,7 +150,6 @@ completed-older:
   runtime_constraints:
     vcpus: 1
     ram: 123
-  mounts: {}
 
 completed_diagnostics:
   name: CWL diagnostics hasher
@@ -433,7 +431,6 @@ requester:
   runtime_constraints:
     vcpus: 1
     ram: 123
-  mounts: {}
 
 cr_for_requester:
   uuid: zzzzz-xvhdp-cr4requestercnt


### PR DESCRIPTION
`464-replace-pyyaml` @ eb99d1079c790606f5266b92ab13b9aae9e3ae3e

https://ci.arvados.org/job/developer-run-tests/5132/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * The replacement of PyYAML in sdk/python/tests/run_test_server.py is mostly straightforward.
  * By default, ruamel.yaml [no longer tolerates duplicate keys](https://yaml.dev/doc/ruamel.yaml/api/#Duplicate_keys) in YAML. This has helped us find some duplicated keys in the services/api test fixtures.
  * I don't _think_ we need to list `ruamel.yaml` in `build/requirements.tests.txt` anymore, because the Python SDK already pulls it in.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Tested with clearing the temp space and run `build/run-tests.sh` from scratch.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_, I think.

Closes #464.